### PR TITLE
add noEmit flag to pre-commit tsc call

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -5,4 +5,4 @@
 echo "Prettifying your code on commit..."
 yarn lint-staged
 echo "Running the TypeScript compiler..."
-yarn tsc
+yarn tsc --noEmit


### PR DESCRIPTION
### Summary <!-- Required -->

Running just `tsc` emits `.js` files in the backend, which messes up with linting and such.

By adding the `--noEmit` flag to the `tsc` command in our precommit hook, we can avoid creating such files.

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

No `.js` files were creating while committing this commit.

### Notes <!-- Optional -->

`tsc` runs pretty slow still, do we want it in our precommit hook at all?

<!--- List any important or subtle points, future considerations, or other items of note. -->