### PR TITLE
Add DB types based on schema

### DIFF
--- a/common/types/db-types.ts
+++ b/common/types/db-types.ts
@@ -1,0 +1,39 @@
+export type DetailedRating = {
+  readonly location: number;
+  readonly safety: number;
+  readonly value: number;
+  readonly maintenance: number;
+  readonly communication: number;
+  readonly conditions: number;
+};
+
+export type Review = {
+  readonly id: string;
+  readonly aptId: string | null;
+  readonly landlordId: string;
+  readonly overallRating: number;
+  readonly detailedRatings: DetailedRating;
+  readonly reviewText: string;
+  readonly date: Date;
+};
+
+export type Landlord = {
+  readonly id: string;
+  readonly name: string;
+  readonly contact: string | null;
+  readonly avgRating: number;
+  readonly photos: readonly string[]; // can be empty
+  readonly reviews: readonly string[]; // array of Review IDs in reviews collection
+  readonly properties: readonly string[]; // array of Apartment IDs in apartments collection
+};
+
+export type Apartment = {
+  readonly id: string;
+  readonly name: string;
+  readonly address: string; // may change to placeID for Google Maps integration
+  readonly landlordId: string | null;
+  readonly numBaths: number | null;
+  readonly numBeds: number | null;
+  readonly photos: string[]; // can be empty
+  readonly area: 'COLLEGETOWN' | 'WEST' | 'NORTH' | 'DOWNTOWN' | 'OTHER';
+};

--- a/common/types/db-types.ts
+++ b/common/types/db-types.ts
@@ -34,6 +34,6 @@ export type Apartment = {
   readonly landlordId: string | null;
   readonly numBaths: number | null;
   readonly numBeds: number | null;
-  readonly photos: string[]; // can be empty
+  readonly photos: readonly string[]; // can be empty
   readonly area: 'COLLEGETOWN' | 'WEST' | 'NORTH' | 'DOWNTOWN' | 'OTHER';
 };


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

After discussing the schema today in this week's sync meeting, we decided on these types. I've added them to a `db-types.ts` file within a new common directory to be shared between the frontend and backend. This way, when you assume that there's some backend endpoint you can call, you can just do `await response.json() as Review` for example to cast it instantly into a review if you know that it follows a certain structure. Similarly, on the frontend we can now expect that these endpoints return a certain type.

### Test Plan <!-- Required -->

n/a
