### PR TITLE
Add API request logging to Express server

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "server.ts",
   "scripts": {
-    "tsc": "tsc", 
+    "tsc": "tsc",
     "test": "NODE_ENV=test firebase emulators:exec --only firestore \"./test.sh\"",
     "start": "ts-node src/server.ts"
   },
@@ -21,8 +21,12 @@
     "firebase": "^8.0.1",
     "firebase-admin": "^9.3.0",
     "fuse.js": "^6.4.6",
+    "morgan": "^1.10.0",
     "supertest": "^6.1.3",
     "ts-node": "^9.1.1",
     "typescript": "^4.0.5"
+  },
+  "devDependencies": {
+    "@types/morgan": "^1.9.2"
   }
 }

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,6 +1,7 @@
 import express, { Express } from 'express';
 import cors from 'cors';
 import Fuse from 'fuse.js';
+import morgan from 'morgan';
 import { db } from './firebase-config';
 import { Section } from './firebase-config/types';
 import { Review, Landlord, Apartment } from '../../common/types/db-types';
@@ -17,8 +18,9 @@ app.use(
     origin: 'http://localhost:3000',
   })
 );
+app.use(morgan('combined'));
 
-app.get('/', async (req, res) => {
+app.get('/', async (_, res) => {
   const snapshot = await db.collection('faqs').get();
 
   const faqs: Section[] = [];

--- a/yarn.lock
+++ b/yarn.lock
@@ -2520,6 +2520,13 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.4.tgz#f0ec25dbf2f0e4b18647313ac031134ca5b24b21"
   integrity sha512-1z8k4wzFnNjVK/tlxvrWuK5WMt6mydWWP7+zvH5eFep4oj+UkrfiJTRtjCeBXNpwaA/FYqqtb4/QS4ianFpIRA==
 
+"@types/morgan@^1.9.2":
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/@types/morgan/-/morgan-1.9.2.tgz#450f958a4d3fb0694a3ba012b09c8106f9a2885e"
+  integrity sha512-edtGMEdit146JwwIeyQeHHg9yID4WSolQPxpEorHmN3KuytuCHyn2ELNr5Uxy8SerniFbbkmgKMrGM933am5BQ==
+  dependencies:
+    "@types/node" "*"
+
 "@types/node@*", "@types/node@>=12.12.47":
   version "14.14.37"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.37.tgz#a3dd8da4eb84a996c36e331df98d82abd76b516e"
@@ -3662,6 +3669,13 @@ base@^0.11.1:
     isobject "^3.0.1"
     mixin-deep "^1.2.0"
     pascalcase "^0.1.1"
+
+basic-auth@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/basic-auth/-/basic-auth-2.0.1.tgz#b998279bf47ce38344b4f3cf916d4679bbf51e3a"
+  integrity sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==
+  dependencies:
+    safe-buffer "5.1.2"
 
 batch@0.6.1:
   version "0.6.1"
@@ -5130,6 +5144,11 @@ depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
+
+depd@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
+  integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
 
 des.js@^1.0.0:
   version "1.0.1"
@@ -9194,6 +9213,17 @@ mkdirp@1.x, mkdirp@^1.0.3, mkdirp@^1.0.4:
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
   dependencies:
     minimist "^1.2.5"
+
+morgan@^1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.10.0.tgz#091778abc1fc47cd3509824653dae1faab6b17d7"
+  integrity sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==
+  dependencies:
+    basic-auth "~2.0.1"
+    debug "2.6.9"
+    depd "~2.0.0"
+    on-finished "~2.3.0"
+    on-headers "~1.0.2"
 
 move-concurrently@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This PR adds HTTP request logging to our backend, as a quality of life feature so that you can tell when we're polling too much in a `useEffect` hook or something in the future, or if needless calls are being made in general.

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

Run `yarn start` to run the frontend and backend concurrently. Try doing something in the frontend that fetches from the Express server and see that it gets logged as expected.

![image](https://user-images.githubusercontent.com/7517829/115161768-81883980-a06d-11eb-9dc1-c893c0c2a3fd.png)

### Notes

Make sure to run `yarn install` after this PR gets merged and you pull from `main`!