### PR TITLE
Redirect to landlord review page after searching

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -4,7 +4,14 @@ import Fuse from 'fuse.js';
 import morgan from 'morgan';
 import { db } from './firebase-config';
 import { Section } from './firebase-config/types';
-import { Review, Landlord, Apartment } from '../../common/types/db-types';
+import {
+  Review,
+  Landlord,
+  LandlordWithId,
+  LandlordWithType,
+  ApartmentWithType,
+  ApartmentWithId,
+} from '../../common/types/db-types';
 import authenticate from './auth';
 
 const app: Express = express();
@@ -58,6 +65,17 @@ app.get('/reviews/:idType/:id', async (req, res) => {
   res.status(200).send(JSON.stringify(reviews));
 });
 
+app.get('/apts/:id', async (req, res) => {
+  try {
+    const { id } = req.params;
+    const snapshot = await aptCollection.doc(id).get();
+    const aptDoc = { id, ...snapshot.data() } as ApartmentWithId;
+    res.status(200).send(JSON.stringify(aptDoc));
+  } catch (err) {
+    res.status(400).send(err);
+  }
+});
+
 app.post('/landlords', async (req, res) => {
   try {
     const doc = landlordCollection.doc();
@@ -69,21 +87,39 @@ app.post('/landlords', async (req, res) => {
   }
 });
 
+const isLandlord = (obj: LandlordWithId | ApartmentWithId): boolean => {
+  const keys = Object.keys(obj);
+  return keys.includes('contact');
+};
+
 app.get('/reviews', async (req, res) => {
   try {
     const query = req.query.q as string;
     const landlordDocs = (await landlordCollection.get()).docs;
-    const landlords: Landlord[] = landlordDocs.map((landlord) => landlord.data() as Landlord);
+    // eslint-disable-next-line
+    const landlords: LandlordWithId[] = landlordDocs.map((landlord) => {
+      return { id: landlord.id, ...landlord.data() } as LandlordWithId;
+    });
     const aptDocs = (await aptCollection.get()).docs;
-    const apts: Apartment[] = aptDocs.map((apt) => apt.data() as Apartment);
-    const aptsLandlords: (Landlord | Apartment)[] = [...landlords, ...apts];
+    // eslint-disable-next-line
+    const apts: ApartmentWithId[] = aptDocs.map((apt) => {
+      return { id: apt.id, ...apt.data() } as ApartmentWithId;
+    });
+    const aptsLandlords: (LandlordWithId | ApartmentWithId)[] = [...landlords, ...apts];
 
     const options = {
       keys: ['name', 'address'],
     };
     const fuse = new Fuse(aptsLandlords, options);
     const results = fuse.search(query);
-    res.status(200).send(JSON.stringify(results.map((result) => result.item)));
+    const resultItems = results.map((result) => result.item);
+
+    const resultsWithType: (LandlordWithType | ApartmentWithType)[] = resultItems.map((result) =>
+      isLandlord(result)
+        ? ({ type: 'LANDLORD', ...result } as LandlordWithType)
+        : ({ type: 'APARTMENT', ...result } as ApartmentWithType)
+    );
+    res.status(200).send(JSON.stringify(resultsWithType));
   } catch (err) {
     res.status(400).send(err);
   }

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -8,8 +8,8 @@ import {
   Review,
   Landlord,
   LandlordWithId,
-  LandlordWithType,
-  ApartmentWithType,
+  LandlordWithLabel,
+  ApartmentWithLabel,
   ApartmentWithId,
 } from '../../common/types/db-types';
 import authenticate from './auth';
@@ -96,15 +96,13 @@ app.get('/reviews', async (req, res) => {
   try {
     const query = req.query.q as string;
     const landlordDocs = (await landlordCollection.get()).docs;
-    // eslint-disable-next-line
-    const landlords: LandlordWithId[] = landlordDocs.map((landlord) => {
-      return { id: landlord.id, ...landlord.data() } as LandlordWithId;
-    });
+    const landlords: LandlordWithId[] = landlordDocs.map(
+      (landlord) => ({ id: landlord.id, ...landlord.data() } as LandlordWithId)
+    );
     const aptDocs = (await aptCollection.get()).docs;
-    // eslint-disable-next-line
-    const apts: ApartmentWithId[] = aptDocs.map((apt) => {
-      return { id: apt.id, ...apt.data() } as ApartmentWithId;
-    });
+    const apts: ApartmentWithId[] = aptDocs.map(
+      (apt) => ({ id: apt.id, ...apt.data() } as ApartmentWithId)
+    );
     const aptsLandlords: (LandlordWithId | ApartmentWithId)[] = [...landlords, ...apts];
 
     const options = {
@@ -114,10 +112,10 @@ app.get('/reviews', async (req, res) => {
     const results = fuse.search(query);
     const resultItems = results.map((result) => result.item);
 
-    const resultsWithType: (LandlordWithType | ApartmentWithType)[] = resultItems.map((result) =>
+    const resultsWithType: (LandlordWithLabel | ApartmentWithLabel)[] = resultItems.map((result) =>
       isLandlord(result)
-        ? ({ type: 'LANDLORD', ...result } as LandlordWithType)
-        : ({ type: 'APARTMENT', ...result } as ApartmentWithType)
+        ? ({ label: 'LANDLORD', ...result } as LandlordWithLabel)
+        : ({ label: 'APARTMENT', ...result } as ApartmentWithLabel)
     );
     res.status(200).send(JSON.stringify(resultsWithType));
   } catch (err) {

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -87,10 +87,7 @@ app.post('/landlords', async (req, res) => {
   }
 });
 
-const isLandlord = (obj: LandlordWithId | ApartmentWithId): boolean => {
-  const keys = Object.keys(obj);
-  return keys.includes('contact');
-};
+const isLandlord = (obj: LandlordWithId | ApartmentWithId): boolean => 'contact' in obj;
 
 app.get('/reviews', async (req, res) => {
   try {

--- a/common/types/db-types.ts
+++ b/common/types/db-types.ts
@@ -2,10 +2,6 @@ type Id = {
   readonly id: string;
 };
 
-type Type = {
-  readonly type: 'LANDLORD' | 'APARTMENT';
-};
-
 export type DetailedRating = {
   readonly location: number;
   readonly safety: number;
@@ -36,7 +32,7 @@ export type Landlord = {
 };
 
 export type LandlordWithId = Landlord & Id;
-export type LandlordWithType = LandlordWithId & Type;
+export type LandlordWithLabel = LandlordWithId & { readonly label: 'LANDLORD' };
 
 export type Apartment = {
   readonly name: string;
@@ -49,4 +45,4 @@ export type Apartment = {
 };
 
 export type ApartmentWithId = Apartment & Id;
-export type ApartmentWithType = ApartmentWithId & Type;
+export type ApartmentWithLabel = ApartmentWithId & { readonly label: 'APARTMENT' };

--- a/common/types/db-types.ts
+++ b/common/types/db-types.ts
@@ -2,6 +2,10 @@ type Id = {
   readonly id: string;
 };
 
+type Type = {
+  readonly type: 'LANDLORD' | 'APARTMENT';
+};
+
 export type DetailedRating = {
   readonly location: number;
   readonly safety: number;
@@ -32,6 +36,7 @@ export type Landlord = {
 };
 
 export type LandlordWithId = Landlord & Id;
+export type LandlordWithType = LandlordWithId & Type;
 
 export type Apartment = {
   readonly name: string;
@@ -44,3 +49,4 @@ export type Apartment = {
 };
 
 export type ApartmentWithId = Apartment & Id;
+export type ApartmentWithType = ApartmentWithId & Type;

--- a/frontend/src/components/Home/Autocomplete.tsx
+++ b/frontend/src/components/Home/Autocomplete.tsx
@@ -14,8 +14,8 @@ import {
 import get, { backendUrl } from '../../utils/get';
 import {
   ApartmentWithId,
-  ApartmentWithType,
-  LandlordWithType,
+  ApartmentWithLabel,
+  LandlordWithLabel,
 } from '../../../../common/types/db-types';
 import SearchIcon from '@material-ui/icons/Search';
 import { makeStyles } from '@material-ui/core/styles';
@@ -37,20 +37,11 @@ export default function Autocomplete() {
   const inputRef = useRef<HTMLDivElement>(document.createElement('div'));
   const [loading, setLoading] = useState(false);
   const [open, setOpen] = useState(false);
-  const [options, setOptions] = useState<(LandlordWithType | ApartmentWithType)[]>([]);
+  const [options, setOptions] = useState<(LandlordWithLabel | ApartmentWithLabel)[]>([]);
   const [query, setQuery] = useState('');
-  const [selected, setSelected] = useState<LandlordWithType | ApartmentWithType | null>(null);
+  const [selected, setSelected] = useState<LandlordWithLabel | ApartmentWithLabel | null>(null);
   const [width, setWidth] = useState(inputRef.current.offsetWidth);
   const [selectedId, setSelectedId] = useState('');
-
-  // const handleClose = (
-  //   event: React.MouseEvent<EventTarget>,
-  //   option: ApartmentWithType | LandlordWithType
-  // ) => {
-  //   setQuery(option.name);
-  //   setSelected(option);
-  //   setOpen(false);
-  // };
 
   function handleListKeyDown(event: React.KeyboardEvent) {
     if (event.key === 'Tab') {
@@ -88,12 +79,12 @@ export default function Autocomplete() {
 
   const handleClickMenu = (
     event: React.MouseEvent<EventTarget>,
-    option: LandlordWithType | ApartmentWithType
+    option: LandlordWithLabel | ApartmentWithLabel
   ) => {
     setSelected(option);
-    if (option.type === 'LANDLORD') {
+    if (option.label === 'LANDLORD') {
       setSelectedId(option.id);
-    } else if (option.type === 'APARTMENT') {
+    } else if (option.label === 'APARTMENT') {
       getLandlordIdFromAptId(option.id);
     }
   };
@@ -129,7 +120,7 @@ export default function Autocomplete() {
                             <Typography>{option.name}</Typography>
                           </Grid>
                           <Grid item xl={4}>
-                            <Chip color="primary" label={option.type.toLowerCase()} />
+                            <Chip color="primary" label={option.label.toLowerCase()} />
                           </Grid>
                         </Grid>
                       </MenuItem>
@@ -171,7 +162,7 @@ export default function Autocomplete() {
 
   useEffect(() => {
     if (loading) {
-      get<LandlordWithType | ApartmentWithType>(`/reviews?q=${query}`, setOptions, setLoading);
+      get<LandlordWithLabel | ApartmentWithLabel>(`/reviews?q=${query}`, setOptions, setLoading);
     }
   }, [loading, query]);
 
@@ -183,7 +174,7 @@ export default function Autocomplete() {
         fullWidth
         ref={inputRef}
         value={query}
-        placeholder="Search by renting company or building address"
+        label="Search by renting company or building address"
         className={text}
         variant="outlined"
         onKeyDown={(event) => (event.key === 'ArrowDown' ? setFocus(true) : setFocus(false))}

--- a/frontend/src/components/Home/Autocomplete.tsx
+++ b/frontend/src/components/Home/Autocomplete.tsx
@@ -41,7 +41,7 @@ export default function Autocomplete() {
   const [query, setQuery] = useState('');
   const [selected, setSelected] = useState<LandlordWithType | ApartmentWithType | null>(null);
   const [width, setWidth] = useState(inputRef.current.offsetWidth);
-  const [selectedId, setSelectedId] = useState("");
+  const [selectedId, setSelectedId] = useState('');
 
   // const handleClose = (
   //   event: React.MouseEvent<EventTarget>,
@@ -73,16 +73,18 @@ export default function Autocomplete() {
 
   const getLandlordIdFromAptId = (aptId: string) => {
     axios
-        .get(`${backendUrl}/apts/${aptId}`)
-        .then((response) => {
-          const apt: ApartmentWithId = response.data;
-          const landlordId = apt.landlordId;
-          if (landlordId !== null) {setSelectedId(landlordId)}
-        })
-        .catch((error) => {
-          console.log('error', error);
-        });
-  }
+      .get(`${backendUrl}/apts/${aptId}`)
+      .then((response) => {
+        const apt: ApartmentWithId = response.data;
+        const landlordId = apt.landlordId;
+        if (landlordId !== null) {
+          setSelectedId(landlordId);
+        }
+      })
+      .catch((error) => {
+        console.log('error', error);
+      });
+  };
 
   const handleClickMenu = (
     event: React.MouseEvent<EventTarget>,
@@ -92,7 +94,7 @@ export default function Autocomplete() {
     if (option.type === 'LANDLORD') {
       setSelectedId(option.id);
     } else if (option.type === 'APARTMENT') {
-      getLandlordIdFromAptId(option.id)
+      getLandlordIdFromAptId(option.id);
     }
   };
 
@@ -173,8 +175,9 @@ export default function Autocomplete() {
     }
   }, [loading, query]);
 
-  return (
-    selectedId !== "" ? <Redirect to={`/landlord/${selectedId}`} /> :
+  return selectedId !== '' ? (
+    <Redirect to={`/landlord/${selectedId}`} />
+  ) : (
     <div>
       <TextField
         fullWidth

--- a/frontend/src/utils/get.ts
+++ b/frontend/src/utils/get.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const backendUrl = 'http://localhost:8080';
+export const backendUrl = 'http://localhost:8080';
 
 export default function get<T>(
   route: string,


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

- [x] created new Apartment and Landlord types with a type field that is either `'LANDLORD '`or `'APARTMENT'`
- [x] used the new types to add labels to the options listed in the autocomplete search
- [x] implemented get request to get an `ApartmentWithId` from an aptId
- [x] implemented logic to redirect to landlord page if the selected option is a landlord, and get the landlord id associated with an apt if the selected option is an apt, and redirect to the landlord associated with it 

### Test Plan <!-- Required -->
Run `yarn start` in the root folder and enter queries into the search bar. Select an option by clicking on it or hitting enter and whether you select a landlord or an apt, it redirects to a landlord review page. Some possible queries: landlord, collegetown.

https://user-images.githubusercontent.com/31854132/116662316-9f09ad00-a963-11eb-9137-5410ef4caa03.mov


<!-- Provide screenshots or point out the additional unit tests -->

### Notes
<!--- List any important or subtle points, future considerations, or other items of note. -->
- The redirect only works when clicking on a menu item or hitting enter, but it does not work by clicking the search icon. I'm not quite sure what we want to do with the search icon. If there are no matches to the query and they hit search, what do we want to happen? I was thinking that as the user goes down the menu with the up and down arrows, the option that is being focused should appear in the search bar, and redirect when they click the search icon, I tried implementing this with an onFocus on the menuItem setQuery to that option, but the up and down arrows stopped working, so I would need to figure out how to implement that with focus. 
- When the selected option is an apartment, even though it has a landlordId field, it cannot be accessed because the option has a type of `LandlordWithType | ApartmentWithType` and landlord doesn't have a landlordId field. This is why I set up a get request to get an ApartmentWithId from an aptId and access its landlordId field.