### PR TITLE
Change implementation for getting landlordId from Apartment

### DIFF
--- a/frontend/src/components/Home/Autocomplete.tsx
+++ b/frontend/src/components/Home/Autocomplete.tsx
@@ -11,15 +11,10 @@ import {
   TextField,
   Typography,
 } from '@material-ui/core';
-import get, { backendUrl } from '../../utils/get';
-import {
-  ApartmentWithId,
-  ApartmentWithLabel,
-  LandlordWithLabel,
-} from '../../../../common/types/db-types';
+import get from '../../utils/get';
+import { ApartmentWithLabel, LandlordWithLabel } from '../../../../common/types/db-types';
 import SearchIcon from '@material-ui/icons/Search';
 import { makeStyles } from '@material-ui/core/styles';
-import axios from 'axios';
 
 const useStyles = makeStyles({
   menuList: {
@@ -41,7 +36,7 @@ export default function Autocomplete() {
   const [query, setQuery] = useState('');
   const [selected, setSelected] = useState<LandlordWithLabel | ApartmentWithLabel | null>(null);
   const [width, setWidth] = useState(inputRef.current.offsetWidth);
-  const [selectedId, setSelectedId] = useState('');
+  const [selectedId, setSelectedId] = useState<string | null>('');
 
   function handleListKeyDown(event: React.KeyboardEvent) {
     if (event.key === 'Tab') {
@@ -62,31 +57,22 @@ export default function Autocomplete() {
     console.log('clicked');
   };
 
-  const getLandlordIdFromAptId = (aptId: string) => {
-    axios
-      .get(`${backendUrl}/apts/${aptId}`)
-      .then((response) => {
-        const apt: ApartmentWithId = response.data;
-        const landlordId = apt.landlordId;
-        if (landlordId !== null) {
-          setSelectedId(landlordId);
-        }
-      })
-      .catch((error) => {
-        console.log('error', error);
-      });
+  const getLandlordId = (option: LandlordWithLabel | ApartmentWithLabel) => {
+    switch (option.label) {
+      case 'LANDLORD':
+        return option.id;
+      case 'APARTMENT':
+        return option.landlordId;
+      default:
+        return null;
+    }
   };
 
   const handleClickMenu = (
     event: React.MouseEvent<EventTarget>,
     option: LandlordWithLabel | ApartmentWithLabel
   ) => {
-    setSelected(option);
-    if (option.label === 'LANDLORD') {
-      setSelectedId(option.id);
-    } else if (option.label === 'APARTMENT') {
-      getLandlordIdFromAptId(option.id);
-    }
+    setSelectedId(getLandlordId(option));
   };
 
   const Menu = () => {


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

Initially I couldn't access the landlordId of an Apartment option because it gave me the error that landlordId does not exist on type ApartmentWithLabel | LandlordWithLabel, so I implemented a get request in the backend to get an apartment from an apartment id, which was an unnecessary request because we already have the apartment. I found out that with a switch statement it doesn't give that error, so I changed the implementation to a switch statement to get the landlordId.

### Test Plan <!-- Required -->
Run `yarn start` in the root folder and search. Both landlords and apartments that are selected redirect to the landlord review page as before.
<!-- Provide screenshots or point out the additional unit tests -->

