### PR TITLE
Fix UI/console bugs, decrease search bar label length

### DIFF
--- a/frontend/src/components/Home/Autocomplete.tsx
+++ b/frontend/src/components/Home/Autocomplete.tsx
@@ -44,8 +44,8 @@ export default function Autocomplete() {
   const [selectedId, setSelectedId] = useState('');
 
   function handleListKeyDown(event: React.KeyboardEvent) {
+    event.preventDefault();
     if (event.key === 'Tab') {
-      event.preventDefault();
       setOpen(false);
     }
   }
@@ -161,7 +161,7 @@ export default function Autocomplete() {
   }, [inputRef, width]);
 
   useEffect(() => {
-    if (loading) {
+    if (loading && query.trim() !== '') {
       get<LandlordWithLabel | ApartmentWithLabel>(`/reviews?q=${query}`, setOptions, setLoading);
     }
   }, [loading, query]);
@@ -174,7 +174,7 @@ export default function Autocomplete() {
         fullWidth
         ref={inputRef}
         value={query}
-        label="Search by renting company or building address"
+        label="Search by landlord or building address"
         className={text}
         variant="outlined"
         onKeyDown={(event) => (event.key === 'ArrowDown' ? setFocus(true) : setFocus(false))}

--- a/frontend/src/components/Landlord/Header.tsx
+++ b/frontend/src/components/Landlord/Header.tsx
@@ -124,13 +124,7 @@ const LandlordHeader = ({ name, overallRating, numReviews, handleClick }: Props)
                   bottom: '20px',
                 }}
               >
-                <Grid
-                  container
-                  xs={12}
-                  direction="row"
-                  style={{ height: '200px' }}
-                  alignItems="flex-end"
-                >
+                <Grid container direction="row" style={{ height: '200px' }} alignItems="flex-end">
                   <Grid item xs={12} md={mobileView ? 12 : 3}>
                     <Avatar
                       src={Logo}

--- a/frontend/src/components/Review/Review.tsx
+++ b/frontend/src/components/Review/Review.tsx
@@ -58,7 +58,7 @@ const ReviewComponent = ({ review }: Props): ReactElement => {
         <CardContent>
           <Grid container spacing={2}>
             <Grid item container justify="space-between">
-              <Grid container xs={10} spacing={2}>
+              <Grid container spacing={2}>
                 <Grid item>
                   <HeartRating value={overallRating} readOnly />
                 </Grid>


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This PR fixes a frontend console error that was logging because of the `xs` property being improperly applied to non Grid Item elements, as well as a search bar bug where if you press the down arrow key, it scrolls down the page instead of going down the list of autocomplete results. In addition, it decreases the length of the search bar label so that it doesn't overflow on mobile small screens.

### Test Plan <!-- Required -->

Run `yarn start`. Check that the console doesn't log any errors anymore when visiting a landlord review page. Press the down arrow key when searching and it should not scroll the entire page down while going through the autocomplete results. Also, simulate a mobile view and see that the search text works.
