### PR TITLE
Enforce non-empty reviews

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -52,6 +52,9 @@ app.post('/new-review', authenticate, async (req, res) => {
   try {
     const doc = reviewCollection.doc();
     const review = req.body as Review;
+    if (review.overallRating === 0 || review.reviewText === '') {
+      res.status(401).send('Error: missing fields');
+    }
     doc.set({ ...review, date: new Date(review.date), likes: 0 });
     res.status(201).send(doc.id);
   } catch (err) {


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request closes issue #63 

- [x] Added a check in the backend to not allow posting reviews with no overall rating or review text

### Test Plan <!-- Required -->
Run `yarn start` in root folder and go to `/landlord/1`. Try posting review with no overall rating but with review text, no overall rating and no review text, overall rating and no review text. The form shouldn't be submitted in all three cases. The form gets successfully submitted otherwise.
<!-- Provide screenshots or point out the additional unit tests -->

