### PR TITLE
CD for heroku prod backend on release 

### DIFF
--- a/.github/workflows/heroku-merge.yml
+++ b/.github/workflows/heroku-merge.yml
@@ -1,0 +1,17 @@
+name: Deploy to Heroku prod on merge
+on:
+  push:
+jobs:
+  prod-check:
+    if: ${{ github.ref == 'refs/heads/release' }}
+    runs-on: ubuntu-latest
+    environment:
+      name: prod
+    steps:
+      - run: echo 'Deploying to production server on branch $GITHUB_REF'
+      - uses: actions/checkout@v2
+      - uses: akhileshns/heroku-deploy@v3.12.12
+        with:
+          heroku_api_key: ${{secrets.CUAPTS_HEROKU_SERVICE_KEY_PROD}}
+          heroku_app_name: 'cuapts-backend-prod'
+          heroku_email: 'kjj32@cornell.edu'


### PR DESCRIPTION
### Summary <!-- Required -->

This pull request closes #80: adds CD for the [heroku prod backend ](https://cuapts-backend-prod.herokuapp.com/) whenever a push is made to the `release` branch. `CUAPTS_HEROKU_SERVICE_KEY_PROD` is a DTI github secret that only works in the `prod` environment. 

### Test Plan <!-- Required -->
- No easy way to test Github actions 👀👀👀. Past PRs for CD have run into the same issue. 
- Need to keep an eye out on `release`

<!-- Provide screenshots or point out the additional unit tests -->

