### PR TITLE
Profanity filter

### DIFF
--- a/frontend/src/components/LeaveReview/ReviewModal.tsx
+++ b/frontend/src/components/LeaveReview/ReviewModal.tsx
@@ -167,6 +167,7 @@ const ReviewModal = ({ open, onClose, setOpen, landlordId, onSuccess, toastTime 
       }
       console.log(review);
       setOpen(false);
+      dispatch({ type: 'reset' });
       onSuccess();
     } catch (err) {
       console.log(err);

--- a/frontend/src/components/LeaveReview/ReviewModal.tsx
+++ b/frontend/src/components/LeaveReview/ReviewModal.tsx
@@ -16,6 +16,7 @@ import { DetailedRating, Review } from '../../../../common/types/db-types';
 import { splitArr } from '../../utils';
 import { createAuthHeaders, getUser, uploadFile } from '../../utils/firebase';
 import ReviewRating from './ReviewRating';
+import { includesProfanity } from '../../utils/profanity';
 import Toast from './Toast';
 import styles from './ReviewModal.module.scss';
 
@@ -87,6 +88,7 @@ const ReviewModal = ({ open, onClose, setOpen, landlordId, onSuccess, toastTime 
   const [showError, setShowError] = useState(false);
   const [emptyTextError, setEmptyTextError] = useState(false);
   const [ratingError, setRatingError] = useState(false);
+  const [includesProfanityError, setIncludesProfanityError] = useState(false);
 
   const updateOverall = () => {
     return (_: React.ChangeEvent<{}>, value: number | null) => {
@@ -153,9 +155,10 @@ const ReviewModal = ({ open, onClose, setOpen, landlordId, onSuccess, toastTime 
       }
       const token = await user.getIdToken(true);
       const data = await formDataToReview(review);
-      if (data.reviewText === '' || data.overallRating === 0) {
+      if (data.reviewText === '' || data.overallRating === 0 || includesProfanity(data.reviewText)) {
         data.overallRating === 0 ? setRatingError(true) : setRatingError(false);
         data.reviewText === '' ? setEmptyTextError(true) : setEmptyTextError(false);
+        includesProfanity(data.reviewText) ? setIncludesProfanityError(true) : setIncludesProfanityError(false);
         return;
       }
       const res = await axios.post('/new-review', data, createAuthHeaders(token));
@@ -284,7 +287,7 @@ const ReviewModal = ({ open, onClose, setOpen, landlordId, onSuccess, toastTime 
             <Grid container item>
               <TextField
                 required={true}
-                error={emptyTextError}
+                error={emptyTextError || includesProfanityError}
                 fullWidth
                 id="body"
                 label="Review"
@@ -294,9 +297,8 @@ const ReviewModal = ({ open, onClose, setOpen, landlordId, onSuccess, toastTime 
                   maxlength: REVIEW_CHARACTER_LIMIT,
                 }}
                 placeholder="Write your review here"
-                helperText={`${review.body.length}/${REVIEW_CHARACTER_LIMIT}${
-                  emptyTextError ? ' This field is required' : ''
-                }`}
+                helperText={`${review.body.length}/${REVIEW_CHARACTER_LIMIT}${emptyTextError ? ' This field is required' : ''
+                  }${includesProfanityError ? ' This review contains profanity. Please edit it and try again.' : ''}`}
                 onChange={updateBody}
               />
             </Grid>

--- a/frontend/src/components/LeaveReview/ReviewModal.tsx
+++ b/frontend/src/components/LeaveReview/ReviewModal.tsx
@@ -155,10 +155,16 @@ const ReviewModal = ({ open, onClose, setOpen, landlordId, onSuccess, toastTime 
       }
       const token = await user.getIdToken(true);
       const data = await formDataToReview(review);
-      if (data.reviewText === '' || data.overallRating === 0 || includesProfanity(data.reviewText)) {
+      if (
+        data.reviewText === '' ||
+        data.overallRating === 0 ||
+        includesProfanity(data.reviewText)
+      ) {
         data.overallRating === 0 ? setRatingError(true) : setRatingError(false);
         data.reviewText === '' ? setEmptyTextError(true) : setEmptyTextError(false);
-        includesProfanity(data.reviewText) ? setIncludesProfanityError(true) : setIncludesProfanityError(false);
+        includesProfanity(data.reviewText)
+          ? setIncludesProfanityError(true)
+          : setIncludesProfanityError(false);
         return;
       }
       const res = await axios.post('/new-review', data, createAuthHeaders(token));
@@ -298,8 +304,13 @@ const ReviewModal = ({ open, onClose, setOpen, landlordId, onSuccess, toastTime 
                   maxlength: REVIEW_CHARACTER_LIMIT,
                 }}
                 placeholder="Write your review here"
-                helperText={`${review.body.length}/${REVIEW_CHARACTER_LIMIT}${emptyTextError ? ' This field is required' : ''
-                  }${includesProfanityError ? ' This review contains profanity. Please edit it and try again.' : ''}`}
+                helperText={`${review.body.length}/${REVIEW_CHARACTER_LIMIT}${
+                  emptyTextError ? ' This field is required' : ''
+                }${
+                  includesProfanityError
+                    ? ' This review contains profanity. Please edit it and try again.'
+                    : ''
+                }`}
                 onChange={updateBody}
               />
             </Grid>

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -8,8 +8,9 @@ import { useEffect } from 'react';
 export const useTitle = (titleOrFn: string | (() => string), ...deps: any[]) => {
   useEffect(
     () => {
-      document.title = ` CU Apartments | ${typeof titleOrFn === 'function' ? titleOrFn() : titleOrFn
-        }`;
+      document.title = ` CU Apartments | ${
+        typeof titleOrFn === 'function' ? titleOrFn() : titleOrFn
+      }`;
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [...deps]

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -8,9 +8,8 @@ import { useEffect } from 'react';
 export const useTitle = (titleOrFn: string | (() => string), ...deps: any[]) => {
   useEffect(
     () => {
-      document.title = ` CU Apartments | ${
-        typeof titleOrFn === 'function' ? titleOrFn() : titleOrFn
-      }`;
+      document.title = ` CU Apartments | ${typeof titleOrFn === 'function' ? titleOrFn() : titleOrFn
+        }`;
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [...deps]

--- a/frontend/src/utils/profanity.ts
+++ b/frontend/src/utils/profanity.ts
@@ -1,0 +1,5 @@
+const Filter = require('bad-words');
+
+const filter = new Filter();
+
+export const includesProfanity = (s: string) => filter.isProfane(s);

--- a/package.json
+++ b/package.json
@@ -64,5 +64,8 @@
   },
   "engines": {
     "node": "14.x"
+  },
+  "dependencies": {
+    "bad-words": "^3.0.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3830,6 +3830,18 @@ babylon@^6.18.0:
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
   integrity sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==
 
+bad-words@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/bad-words/-/bad-words-3.0.4.tgz#044c83935c4c363a905d47b5e0179f7241fecaec"
+  integrity sha512-v/Q9uRPH4+yzDVLL4vR1+S9KoFgOEUl5s4axd6NIAq8SV2mradgi4E8lma/Y0cw1ltVdvyegCQQKffCPRCp8fg==
+  dependencies:
+    badwords-list "^1.0.0"
+
+badwords-list@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/badwords-list/-/badwords-list-1.0.0.tgz#5e9856dbf13482a295c3b0b304afb9d4cfc5c579"
+  integrity sha1-XphW2/E0gqKVw7CzBK+51M/FxXk=
+
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request implements checking for profanity before submitting a review.

- [x] Closes issue #84 
- [x] Implemented a profanity filter that checks for profanity in the onSubmit() function in the ReviewModal. 
- [x] Created a type for the profanity filter that can be modified to add additional words to the filter later on.
- [X] The current modal from the main branch allowed the user to submit an empty review if they submit a valid review and click the leave a review and the submit button again without entering review text or an overall experience rating. This bug was fixed in this PR.

### Test Plan <!-- Required -->
Run `yarn start` in the root folder. Choose renting companies from the homepage. On the renting company review page, click on the "leave a review" button. 
- Try pressing the "submit" button and confirm that it does not allow submission. 
- Try selecting a number for the overall experience, try submitting again, and confirm it doesn't allow submission, and the helper text below the review text field says "This field is required"
- Try writing a profane word in the review text, and try submitting. Confirm that submission is not allowed, and the helper text says "This review contains profanity. Please edit it and try again."
- Remove the profane word, and write something normal. Try submitting, and confirm the submission works.
- Press the "leave a review" button again, and try pressing the "submit" button without selecting an overall experience rating, and without typing anything in the review field. Confirm that the submission is not allowed.