### PR TITLE
Remove indent on property info 

### DIFF
--- a/frontend/src/components/Review/PropertyInfo.tsx
+++ b/frontend/src/components/Review/PropertyInfo.tsx
@@ -16,7 +16,7 @@ export default function PropertyInfo({ info, title }: Props): ReactElement {
           {info.length === 0 && <Typography>No information available.</Typography>}
           {info.map((feature, index) => (
             <Grid item xs={6} sm={12} md={6} key={index}>
-              <ListItem>
+              <ListItem disableGutters>
                 <ListItemText primary={feature} />
               </ListItem>
             </Grid>


### PR DESCRIPTION
### Summary <!-- Required -->

Makes a minor CSS change by removing the indentation on the side of the property names. 
Before: 

<img width="392" alt="Screen Shot 2021-11-03 at 8 59 15 PM" src="https://user-images.githubusercontent.com/57203639/140239803-15f9043f-6a25-4247-8e6c-295dd0d272fa.png">
After: 
<img width="405" alt="Screen Shot 2021-11-03 at 8 57 11 PM" src="https://user-images.githubusercontent.com/57203639/140239634-7f3a3d6a-db3f-41ba-a7d0-e4567442e410.png">