### PR TITLE
Temporary building limit

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -159,7 +159,7 @@ app.get('/search', async (req, res) => {
 
 app.get('/page-data/:page', async (req, res) => {
   const { page } = req.params;
-  const collection = page === 'home' ? buildingsCollection.limit(3) : buildingsCollection;
+  const collection = page === 'home' ? buildingsCollection.limit(3) : buildingsCollection.limit(12);
   const buildingDocs = (await collection.get()).docs;
   const buildings: Apartment[] = buildingDocs
     .map((doc) => doc.data() as Apartment)


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This PR adds a temporary limit on the number of buildings and their data fetched from the `buildings` collection in the DB. This limit is necessary to prevent excessively high amounts of reads until we optimize the way we retrieve this data. See #116. 
