### PR TITLE
Other properties owned on apartment page

### DIFF
--- a/frontend/src/components/Apartment/AptInfo.tsx
+++ b/frontend/src/components/Apartment/AptInfo.tsx
@@ -1,19 +1,22 @@
 import React, { ReactElement } from 'react';
 import Info from './Info';
 import { Card, CardContent, Divider } from '@material-ui/core';
+import PropertyInfo from '../Review/PropertyInfo';
 
 type Props = {
   readonly landlord: string;
   readonly contact: string | null;
   readonly address: string | null;
+  readonly buildings: readonly string[];
 };
 
-export default function AptInfo({ landlord, contact, address }: Props): ReactElement {
+export default function AptInfo({ landlord, contact, address, buildings }: Props): ReactElement {
   return (
     <Card variant="outlined">
       <CardContent>
         <Info landlord={landlord} contact={contact!} address={address!} />
         <Divider />
+        <PropertyInfo title="Other Properties Owned" info={buildings} />
       </CardContent>
     </Card>
   );

--- a/frontend/src/pages/ApartmentPage.tsx
+++ b/frontend/src/pages/ApartmentPage.tsx
@@ -245,7 +245,12 @@ const ApartmentPage = (): ReactElement => {
 
   const InfoSection = landlordData && (
     <Grid item xs={12} sm={4}>
-      <AptInfo landlord={landlordData.name} contact={landlordData.contact} address={apt!.address} />
+      <AptInfo
+        landlord={landlordData.name}
+        contact={landlordData.contact}
+        address={apt!.address}
+        buildings={buildings.map((b) => b.name).filter((name) => name !== apt?.name)}
+      />
     </Grid>
   );
 


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This PR closes #140 by populating informational side bar on the apartment page with the names of other properties owned by the same landlord. 
<img width="1211" alt="Screen Shot 2022-02-01 at 8 33 18 PM" src="https://user-images.githubusercontent.com/57203639/152080661-24da61c4-f202-4b77-82f6-631444b31e31.png">

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
- Navigate to `http://localhost:3000/apartment/211` or an apartment of your choice. 
- Check that the side bar shows the names of other properties 
- If the landlord only owns that one apartment, then it should just say "Other Properties Owned" with nothing underneath. 
