### PR TITLE
Display average rating number

### DIFF
--- a/frontend/src/components/Apartment/Header.tsx
+++ b/frontend/src/components/Apartment/Header.tsx
@@ -8,6 +8,7 @@ import {
   withStyles,
   makeStyles,
   Avatar,
+  Typography,
 } from '@material-ui/core';
 import styles from './Header.module.scss';
 import { ApartmentWithId } from '../../../../common/types/db-types';
@@ -95,12 +96,9 @@ const useStyles = makeStyles((theme) => ({
     },
   },
   aptRating: {
-    paddingTop: '5px',
+    color: 'white',
     marginRight: '45px',
-    '& div': {
-      display: 'inline-block',
-      marginTop: '2px',
-    },
+    marginBottom: '2px',
   },
   headerSection: {
     [theme.breakpoints.down('sm')]: {
@@ -154,12 +152,25 @@ const ApartmentHeader = ({
                 <Grid className={headerSection}>
                   <CardHeader title={name} className={aptName} disableTypography={true} />
                   <Grid container className={ratingSection}>
-                    <Grid item className={aptRating} xs={12}>
-                      <HeartRating value={averageRating} precision={0.5} readOnly />
-                    </Grid>
+                    {!!averageRating && (
+                      <Grid item className={aptRating} xs={12}>
+                        <Grid container direction="row" alignItems="center">
+                          <Grid item xs={5}>
+                            <HeartRating value={averageRating} precision={0.5} readOnly />
+                          </Grid>
+                          <Grid item xs={7}>
+                            <Typography variant="h6">
+                              {averageRating.toFixed(1) + ' out of 5'}
+                            </Typography>
+                          </Grid>
+                        </Grid>
+                      </Grid>
+                    )}
                     <Grid item xs={12}>
                       <CardHeader
-                        title={numReviews + (numReviews > 1 ? ' Reviews' : ' Review')}
+                        title={
+                          numReviews + (numReviews > 1 || numReviews === 0 ? ' Reviews' : ' Review')
+                        }
                         className={aptReviews}
                         disableTypography={true}
                       />


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This PR closes #141 by: 
- Adds the average rating number in the header for an apartment
- Removes the empty hearts if an apartment does not have any reviews — this is consistent with other review-based platforms such as Amazon
- Changes the text to say "0 Reviews" instead of "0 Review"
<img width="1251" alt="Screen Shot 2022-02-01 at 9 38 02 PM" src="https://user-images.githubusercontent.com/57203639/152085225-7213e936-7e99-4b3f-8564-a14c98d2ef9f.png">
<img width="1263" alt="Screen Shot 2022-02-01 at 9 38 30 PM" src="https://user-images.githubusercontent.com/57203639/152085226-c2302718-fb90-4eb4-9a91-758290bc6455.png">


### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
- Navigate to `http://localhost:3000/apartment/200`: check that the empty hearts do not appear
- Navigate to `http://localhost:3000/apartment/210`: check that the average rating appears next to the hearts. 

