### PR TITLE
Location cards on home page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -55,6 +55,11 @@ export type CardData = {
   company?: string;
 };
 
+export type LocationCardData = {
+  photo: string;
+  location: string;
+};
+
 const headersData = [home, review];
 
 hotjar.initialize(HJID, HJSV);

--- a/frontend/src/components/Home/LocationCard.tsx
+++ b/frontend/src/components/Home/LocationCard.tsx
@@ -18,9 +18,6 @@ const useStyles = makeStyles({
   card: {
     borderRadius: '10px',
   },
-  // cardContent: {
-  //   paddingBottom: 0,
-  // },
   cardContent: {
     padding: '12px',
     '&:last-child': {

--- a/frontend/src/components/Home/LocationCard.tsx
+++ b/frontend/src/components/Home/LocationCard.tsx
@@ -1,0 +1,57 @@
+import React, { ReactElement } from 'react';
+import ApartmentImg from '../../assets/apartment-sample.png';
+import { Card, CardContent, CardMedia, Grid, makeStyles, Typography } from '@material-ui/core';
+
+type Props = {
+  readonly photo: string;
+  readonly location: string;
+};
+
+const useStyles = makeStyles({
+  img: {
+    height: 200,
+    width: '100%',
+  },
+  nameText: {
+    fontWeight: 600,
+  },
+  card: {
+    borderRadius: '10px',
+  },
+  // cardContent: {
+  //   paddingBottom: 0,
+  // },
+  cardContent: {
+    padding: '12px',
+    '&:last-child': {
+      paddingBottom: '12px',
+    },
+  },
+});
+
+const LocationCard = ({ photo, location }: Props): ReactElement => {
+  const img = photo ? photo : ApartmentImg;
+
+  const classes = useStyles();
+
+  return (
+    <Card className={classes.card}>
+      <CardMedia className={classes.img} image={img} component="img" title={location} />
+      <CardContent className={classes.cardContent}>
+        <Grid container spacing={1}>
+          <Grid container item justify="center" alignItems="center">
+            <Grid item>
+              <Grid container alignItems="center">
+                <Typography variant="h6" className={classes.nameText}>
+                  {location}
+                </Typography>
+              </Grid>
+            </Grid>
+          </Grid>
+        </Grid>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default LocationCard;

--- a/frontend/src/components/Home/LocationCards.tsx
+++ b/frontend/src/components/Home/LocationCards.tsx
@@ -14,7 +14,7 @@ const LocationCards = ({ data }: Props): ReactElement => {
       {data &&
         data.map(({ photo, location }, index) => {
           return (
-            <Grid item xs={12} md={3} key={index}>
+            <Grid item xs={12} sm={6} md={3} key={index}>
               <Link
                 {...{
                   to: `/`,

--- a/frontend/src/components/Home/LocationCards.tsx
+++ b/frontend/src/components/Home/LocationCards.tsx
@@ -1,0 +1,34 @@
+import React, { ReactElement } from 'react';
+import LocationCard from './LocationCard';
+import { Grid, Link } from '@material-ui/core';
+import { Link as RouterLink } from 'react-router-dom';
+import { LocationCardData } from '../../App';
+
+type Props = {
+  data: LocationCardData[];
+};
+
+const LocationCards = ({ data }: Props): ReactElement => {
+  return (
+    <Grid container spacing={3}>
+      {data &&
+        data.map(({ photo, location }, index) => {
+          return (
+            <Grid item xs={12} md={3} key={index}>
+              <Link
+                {...{
+                  to: `/`,
+                  style: { textDecoration: 'none' },
+                  component: RouterLink,
+                }}
+              >
+                <LocationCard key={index} photo={photo} location={location} />
+              </Link>
+            </Grid>
+          );
+        })}
+    </Grid>
+  );
+};
+
+export default LocationCards;

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -4,7 +4,8 @@ import Autocomplete from '../components/Home/Autocomplete';
 import { get } from '../utils/call';
 import styles from './HomePage.module.scss';
 import ApartmentCards from '../components/ApartmentCard/ApartmentCards';
-import { CardData } from '../App';
+import LocationCards from '../components/Home/LocationCards';
+import { CardData, LocationCardData } from '../App';
 
 const useStyles = makeStyles({
   jumboText: {
@@ -17,11 +18,13 @@ const useStyles = makeStyles({
     fontWeight: 400,
   },
   rentingBox: {
-    marginTop: '3em',
+    marginTop: '2em',
     marginBottom: '2em',
   },
   rentingText: {
+    marginBottom: '1em',
     fontWeight: 500,
+    color: '#B94630',
   },
 });
 
@@ -34,6 +37,25 @@ const HomePage = (): ReactElement => {
       callback: setHomeData,
     });
   }, []);
+
+  const locationData: LocationCardData[] = [
+    {
+      photo: '',
+      location: 'Collegetown',
+    },
+    {
+      photo: '',
+      location: 'West',
+    },
+    {
+      photo: '',
+      location: 'Downtown',
+    },
+    {
+      photo: '',
+      location: 'North',
+    },
+  ];
 
   return (
     <>
@@ -52,14 +74,16 @@ const HomePage = (): ReactElement => {
           </Box>
         </Container>
       </Box>
+
       <Box>
         <Container maxWidth="lg">
-          <Box pb={3} textAlign="left" className={classes.rentingBox}>
+          <Box textAlign="center" className={classes.rentingBox}>
             <Typography variant="h4" className={classes.rentingText}>
-              Browse Housing
+              Find the Best Properties in Ithaca
             </Typography>
-          </Box>
 
+            <LocationCards data={locationData} />
+          </Box>
           <ApartmentCards data={homeData} />
         </Container>
       </Box>


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This PR closes #159 by implementing the location cards for ctown, west, downtown, and north. Right now the cards do not link to anything because the search results page needs to be created first. 
<img width="700" alt="Screen Shot 2022-03-17 at 1 18 37 PM" src="https://user-images.githubusercontent.com/57203639/158859942-b5fdc355-7f7d-46e6-8b14-1ae76b839397.png">



https://user-images.githubusercontent.com/57203639/158859988-b4a56f7f-e4e8-4691-9667-0af88f60f507.mov



### Test Plan <!-- Required -->
- Navigate to the root directory and run `yarn start`
- On a medium-large screen size, the four cards should take up one row
- On a small screen, there should be two rows, each containing two cards 
- On a very small screen, there should be four rows, each containing one card 

<!-- Provide screenshots or point out the additional unit tests -->
