### PR TITLE
Create a blank search results page that pops up when clicking enter in search bar

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import { hotjar } from 'react-hotjar';
 import { HJID, HJSV } from './constants/hotjar';
 import Policies from './pages/Policies';
 import ApartmentPage from './pages/ApartmentPage';
+import SearchResultsPage from './pages/SearchResultsPage';
 
 const theme = createMuiTheme({
   palette: {
@@ -72,7 +73,8 @@ const App = (): ReactElement => {
             <Route exact path="/policies" component={Policies} />
             <Route path="/landlord/:landlordId" component={LandlordPage} />
             <Route path="/apartment/:aptId" component={ApartmentPage} />
-            <Route component={NotFoundPage} />
+            <Route exact path="/notfound" component={NotFoundPage} />
+            <Route exact path="/searchresults" component={SearchResultsPage} />
           </Switch>
         </div>
         <Footer />

--- a/frontend/src/components/Home/Autocomplete.tsx
+++ b/frontend/src/components/Home/Autocomplete.tsx
@@ -15,6 +15,7 @@ import { LandlordOrApartmentWithLabel } from '../../../../common/types/db-types'
 import SearchIcon from '@material-ui/icons/Search';
 import { makeStyles } from '@material-ui/core/styles';
 import { Link as RouterLink } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
 
 const useStyles = makeStyles((theme) => ({
   menuList: {
@@ -58,11 +59,16 @@ export default function Autocomplete() {
   const [query, setQuery] = useState('');
   const [selected, setSelected] = useState<LandlordOrApartmentWithLabel | null>(null);
   const [width, setWidth] = useState(inputRef.current.offsetWidth);
+  const history = useHistory();
 
   function handleListKeyDown(event: React.KeyboardEvent) {
     event.preventDefault();
     if (event.key === 'Tab') {
       setOpen(false);
+    }
+    if (event.key === 'Enter') {
+      setOpen(false);
+      history.push('/searchresults');
     }
   }
 
@@ -179,7 +185,16 @@ export default function Autocomplete() {
         placeholder="Search by landlord or building address"
         className={text}
         variant="outlined"
-        onKeyDown={(event) => (event.key === 'ArrowDown' ? setFocus(true) : setFocus(false))}
+        onKeyDown={(event) => {
+          if (event.key === 'ArrowDown') {
+            setFocus(true);
+          } else if (event.key === 'Enter') {
+            setFocus(true);
+            history.push('/searchresults');
+          } else {
+            setFocus(false);
+          }
+        }}
         onChange={(event) => {
           const value = event.target.value;
           if (value !== '' || value !== null) {
@@ -192,6 +207,7 @@ export default function Autocomplete() {
           className: field,
         }}
       />
+
       <Menu />
     </div>
   );

--- a/frontend/src/pages/SearchResultsPage.tsx
+++ b/frontend/src/pages/SearchResultsPage.tsx
@@ -1,0 +1,18 @@
+import { Box, Container, Typography } from '@material-ui/core';
+import React, { ReactElement } from 'react';
+
+// import NotFoundIcon from '../assets/not-found.svg';
+// import styles from './NotFoundPage.module.css';
+
+const SearchResultsPage = (): ReactElement => {
+  return (
+    <Container maxWidth="md">
+      <Box pb={3} textAlign="center">
+        {/* <img src={NotFoundIcon} alt="CU Apts Logo" className={styles.NotFoundImage} /> */}
+        <Typography variant="h5">EMPTY NOW!</Typography>
+      </Box>
+    </Container>
+  );
+};
+
+export default SearchResultsPage;


### PR DESCRIPTION
### Summary 

This pull request is the first step towards implementing feature [SearchResultsPage]
As soon as  a user press enter in the search bar, it will direct to a now blank search results page.

### Test Plan <!-- Required -->

Not sure how to fully test in React, but a few manual checks confirm that it can direct to a blank page.

