### PR TITLE
Mobile layout & new breakpoints for ApartmentCards

### DIFF
--- a/frontend/src/components/ApartmentCard/ApartmentCard.tsx
+++ b/frontend/src/components/ApartmentCard/ApartmentCard.tsx
@@ -73,16 +73,16 @@ const ApartmentCard = ({ buildingData, numReviews, company }: Props): ReactEleme
     <Card className={classes.card}>
       <Grid container direction="row" alignItems="center">
         {matches && (
-          <Grid item sm={3} xs={11} md={2}>
+          <Grid item sm={4} xs={11} md={2}>
             <CardMedia className={classes.img} image={img} component="img" title={name} />
           </Grid>
         )}
         {!matches && (
-          <Grid item sm={3} xs={11} md={2}>
+          <Grid item sm={4} xs={11} md={2}>
             <CardMedia className={classes.imgMobile} image={img} component="img" title={name} />
           </Grid>
         )}
-        <Grid item sm={9} md={10}>
+        <Grid item sm={8} md={10}>
           <CardContent>
             <Grid container spacing={1}>
               <Grid item>
@@ -103,7 +103,18 @@ const ApartmentCard = ({ buildingData, numReviews, company }: Props): ReactEleme
                   {numReviews + (numReviews !== 1 ? ' Reviews' : ' Review')}
                 </Typography>
               </Grid>
-              <Grid></Grid>
+              <Grid>
+                {matches && (
+                  <Typography variant="subtitle1" className={classes.textStyle}>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+                    incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis
+                    nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+                    incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis
+                    nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+                  </Typography>
+                )}
+              </Grid>
             </Grid>
           </CardContent>
         </Grid>

--- a/frontend/src/components/ApartmentCard/ApartmentCard.tsx
+++ b/frontend/src/components/ApartmentCard/ApartmentCard.tsx
@@ -46,10 +46,6 @@ const useStyles = makeStyles({
     fontWeight: 700,
     marginLeft: '10px',
   },
-  reviewText: {
-    color: 'gray',
-    marginLeft: '25px',
-  },
   textStyle: {
     maxWidth: '100%',
     display: '-webkit-box',

--- a/frontend/src/components/ApartmentCard/ApartmentCard.tsx
+++ b/frontend/src/components/ApartmentCard/ApartmentCard.tsx
@@ -25,6 +25,13 @@ const useStyles = makeStyles({
     width: '100%',
     padding: '17px',
   },
+  imgMobile: {
+    borderRadius: '8%',
+    height: '480px',
+    width: '100%',
+    padding: '20px',
+  },
+
   aptNameTxt: {
     fontWeight: 800,
     marginLeft: '25px',
@@ -60,17 +67,22 @@ const ApartmentCard = ({ buildingData, numReviews, company }: Props): ReactEleme
   const { name, photos } = buildingData;
   const img = photos.length > 0 ? photos[0] : ApartmentImg;
   const classes = useStyles();
-  const matches = useMediaQuery('(min-width:960px)');
+  const matches = useMediaQuery('(min-width:600px)');
 
   return (
     <Card className={classes.card}>
       <Grid container direction="row" alignItems="center">
-        <Grid item md={2}>
-          {matches && (
+        {matches && (
+          <Grid item sm={3} xs={11} md={2}>
             <CardMedia className={classes.img} image={img} component="img" title={name} />
-          )}
-        </Grid>
-        <Grid item md={10}>
+          </Grid>
+        )}
+        {!matches && (
+          <Grid item sm={3} xs={11} md={2}>
+            <CardMedia className={classes.imgMobile} image={img} component="img" title={name} />
+          </Grid>
+        )}
+        <Grid item sm={9} md={10}>
           <CardContent>
             <Grid container spacing={1}>
               <Grid item>
@@ -91,16 +103,7 @@ const ApartmentCard = ({ buildingData, numReviews, company }: Props): ReactEleme
                   {numReviews + (numReviews !== 1 ? ' Reviews' : ' Review')}
                 </Typography>
               </Grid>
-              <Grid>
-                <Typography variant="subtitle1" className={classes.textStyle}>
-                  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
-                  incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
-                  exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Lorem ipsum
-                  dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-                  labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation
-                  ullamco laboris nisi ut aliquip ex ea commodo consequat.
-                </Typography>
-              </Grid>
+              <Grid></Grid>
             </Grid>
           </CardContent>
         </Grid>

--- a/frontend/src/components/ApartmentCard/ApartmentCard.tsx
+++ b/frontend/src/components/ApartmentCard/ApartmentCard.tsx
@@ -19,7 +19,7 @@ type Props = {
   company?: string;
 };
 const useStyles = makeStyles({
-  img: {
+  imgStyle: {
     borderRadius: '12%',
     height: '205px',
     width: '100%',
@@ -61,46 +61,46 @@ const useStyles = makeStyles({
 const ApartmentCard = ({ buildingData, numReviews, company }: Props): ReactElement => {
   const { name, photos } = buildingData;
   const img = photos.length > 0 ? photos[0] : ApartmentImg;
-  const classes = useStyles();
+  const { imgStyle, imgMobile, aptNameTxt, marginTxt, card, reviewNum, textStyle } = useStyles();
   const matches = useMediaQuery('(min-width:600px)');
 
   return (
-    <Card className={classes.card}>
+    <Card className={card}>
       <Grid container direction="row" alignItems="center">
         {matches && (
           <Grid item xs={11} sm={4} md={2}>
-            <CardMedia className={classes.img} image={img} component="img" title={name} />
+            <CardMedia className={imgStyle} image={img} component="img" title={name} />
           </Grid>
         )}
         {!matches && (
           <Grid item xs={11} sm={4} md={2}>
-            <CardMedia className={classes.imgMobile} image={img} component="img" title={name} />
+            <CardMedia className={imgMobile} image={img} component="img" title={name} />
           </Grid>
         )}
         <Grid item sm={8} md={10}>
           <CardContent>
             <Grid container spacing={1}>
               <Grid item>
-                <Typography variant="h5" className={classes.aptNameTxt}>
+                <Typography variant="h5" className={aptNameTxt}>
                   {name}
                 </Typography>
               </Grid>
               {company && (
-                <Grid container item justify="space-between" className={classes.marginTxt}>
+                <Grid container item justify="space-between" className={marginTxt}>
                   <Grid>
                     <Typography variant="subtitle1">{buildingData.address}</Typography>
                   </Grid>
                 </Grid>
               )}
-              <Grid container direction="row" alignItems="center" className={classes.marginTxt}>
+              <Grid container direction="row" alignItems="center" className={marginTxt}>
                 <HeartRating value={3} readOnly />
-                <Typography variant="h6" className={classes.reviewNum}>
+                <Typography variant="h6" className={reviewNum}>
                   {numReviews + (numReviews !== 1 ? ' Reviews' : ' Review')}
                 </Typography>
               </Grid>
               <Grid>
                 {matches && (
-                  <Typography variant="subtitle1" className={classes.textStyle}>
+                  <Typography variant="subtitle1" className={textStyle}>
                     Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
                     incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis
                     nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.

--- a/frontend/src/components/ApartmentCard/ApartmentCard.tsx
+++ b/frontend/src/components/ApartmentCard/ApartmentCard.tsx
@@ -26,7 +26,7 @@ const useStyles = makeStyles({
     padding: '17px',
   },
   imgMobile: {
-    borderRadius: '8%',
+    borderRadius: '9%',
     width: '100%',
     padding: '15px',
   },

--- a/frontend/src/components/ApartmentCard/ApartmentCard.tsx
+++ b/frontend/src/components/ApartmentCard/ApartmentCard.tsx
@@ -27,9 +27,8 @@ const useStyles = makeStyles({
   },
   imgMobile: {
     borderRadius: '8%',
-    height: '480px',
     width: '100%',
-    padding: '20px',
+    padding: '15px',
   },
 
   aptNameTxt: {
@@ -73,12 +72,12 @@ const ApartmentCard = ({ buildingData, numReviews, company }: Props): ReactEleme
     <Card className={classes.card}>
       <Grid container direction="row" alignItems="center">
         {matches && (
-          <Grid item sm={4} xs={11} md={2}>
+          <Grid item xs={11} sm={4} md={2}>
             <CardMedia className={classes.img} image={img} component="img" title={name} />
           </Grid>
         )}
         {!matches && (
-          <Grid item sm={4} xs={11} md={2}>
+          <Grid item xs={11} sm={4} md={2}>
             <CardMedia className={classes.imgMobile} image={img} component="img" title={name} />
           </Grid>
         )}


### PR DESCRIPTION
### Summary <!-- Required -->

This PR closes #176 by changing the layout for mobile devices so the layout corresponds to the [Figma one](https://www.figma.com/file/0PSGWBDpegMHw7QF96Ulww/CUAPTS-SP22?node-id=2420%3A10054). I also edited the Apartment Cards so the image size stays more consistent (not too stretched) when the screen is resized by adding new breakpoints.

### Test Plan <!-- Required -->

https://user-images.githubusercontent.com/60114462/166166817-dc78da1f-2118-4f17-a330-8ae24cc26fde.mov


- The component should resize nicely
- The component should match layout for the mobile screen to Figma mobile screen
