### PR TITLE
Removing Landlords and Adding Apt Cards on the Search Page (1/2)

### DIFF
--- a/frontend/src/pages/SearchResultsPage.tsx
+++ b/frontend/src/pages/SearchResultsPage.tsx
@@ -30,26 +30,15 @@ const SearchResultsPage = (): ReactElement => {
     });
   }, [query]);
 
-  // if properties is in searchItem, then it has the LandlordWithLabel type
-  function isLandlord(searchItem: LandlordOrApartmentWithLabel): searchItem is LandlordWithLabel {
-    return 'properties' in searchItem;
-  }
-  const landlordSearchResults: LandlordWithLabel[] = searchResults.filter(isLandlord).slice(0, 3);
   return (
     <Container>
       <Box pb={5}>
         <Box pb={2}>
           <Typography variant="h5" align="left" className={landlordTitle}>
-            Landlords
+            Placeholder for Apartment Cards
           </Typography>
         </Box>
-        <Grid container spacing={2}>
-          {landlordSearchResults.map((landlordSearchResult) => (
-            <Grid item xs={4} md={4}>
-              <LandlordCard landlordData={landlordSearchResult} />
-            </Grid>
-          ))}
-        </Grid>
+        <Grid container spacing={2}></Grid>
       </Box>
     </Container>
   );


### PR DESCRIPTION
This PR is 1 of 2 parts addressing Issue #184. This PR removes the landlord cards on the search results and adds a placeholder text which will be replaced with apartment cards in the next PR #191 (2/2).

BEFORE:
![image](https://user-images.githubusercontent.com/75141596/194679375-8710233d-94cc-4db0-8291-59d1e3a0ccd1.png)
AFTER:
![image](https://user-images.githubusercontent.com/75141596/194679355-89fb27d2-d018-4ee2-baf8-bf401c3959e2.png)
