### PR TITLE
Fix search result url link to apartment vs. landlord

### DIFF
--- a/frontend/src/components/Home/Autocomplete.tsx
+++ b/frontend/src/components/Home/Autocomplete.tsx
@@ -113,7 +113,7 @@ export default function Autocomplete() {
                       <Link
                         key={index}
                         {...{
-                          to: `/apartment/${id}`,
+                          to: `/${label.toLowerCase()}/${id}`,
                           style: { textDecoration: 'none' },
                           component: RouterLink,
                         }}

--- a/frontend/src/components/Home/Autocomplete.tsx
+++ b/frontend/src/components/Home/Autocomplete.tsx
@@ -88,7 +88,7 @@ export default function Autocomplete() {
       setLoading(false);
     }
   };
-
+  //Menu
   const Menu = () => {
     return (
       <div>


### PR DESCRIPTION
### Summary <!-- Required -->

Previously, making a search query and clicking on a result brings the user to the page for an apartment, even if a landlord was clicked. This pull request fixes the issue by aligning the destination URL with the type of result: `.org/apartment/21` vs. `.org/landlord/21`

### Test Plan <!-- Required -->
Query "f"
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/69334328/194682431-cb0be4d3-0a0b-4ed0-9260-0ef6233e645a.png">

Click on 116 Ferris Place (Apartment)
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/69334328/194682447-ced6939a-f1e3-4a66-b956-06c952fabe41.png">

Click on Fontana Apartments (Landlord)
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/69334328/194682410-f98dc2b0-33dd-418a-b9e6-d7722c603aea.png">


