### PR TITLE
pushing dans PR: Fix search result url link to apartment vs. landlord

### DIFF
--- a/frontend/src/components/Home/Autocomplete.tsx
+++ b/frontend/src/components/Home/Autocomplete.tsx
@@ -113,7 +113,7 @@ export default function Autocomplete() {
                       <Link
                         key={index}
                         {...{
-                          to: `/apartment/${id}`,
+                          to: `/${label.toLowerCase()}/${id}`,
                           style: { textDecoration: 'none' },
                           component: RouterLink,
                         }}


### PR DESCRIPTION
### Summary <!-- Required -->
Previously, making a search query and clicking on a result brings the user to the page for an apartment, even if a landlord was clicked. This pull request fixes the issue by aligning the destination URL with the type of result: .org/apartment/21 vs. .org/landlord/21


### Test Plan <!-- Required -->

![image](https://user-images.githubusercontent.com/60114462/197636826-75adcccc-89bc-4ebd-a26d-da0c8fc77ac8.png)
![image](https://user-images.githubusercontent.com/60114462/197636845-6d5e2f43-3559-4021-ad98-59ea5087f2ff.png)
![image](https://user-images.githubusercontent.com/60114462/197636865-be749d01-2fdf-4a50-8673-7d19a62d4e06.png)
