### PR TITLE
Search Results Page with Apartment Cards (NEW implementation)

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -176,6 +176,7 @@ app.post('/set-data', async (req, res) => {
     res.status(400).send('Error');
   }
 });
+
 app.get('/search', async (req, res) => {
   try {
     const query = req.query.q as string;
@@ -196,6 +197,27 @@ app.get('/search', async (req, res) => {
         : ({ label: 'APARTMENT', ...result } as ApartmentWithLabel)
     );
     res.status(200).send(JSON.stringify(resultsWithType));
+  } catch (err) {
+    console.error(err);
+    res.status(400).send('Error');
+  }
+});
+
+app.get('/search-results', async (req, res) => {
+  try {
+    const query = req.query.q as string;
+    const apts = req.app.get('apts');
+    const aptsWithType: ApartmentWithId[] = apts;
+
+    const options = {
+      keys: ['name', 'address'],
+    };
+
+    const fuse = new Fuse(aptsWithType, options);
+    const results = fuse.search(query);
+    const resultItems = results.map((result) => result.item);
+
+    res.status(200).send(JSON.stringify(await pageData(resultItems)));
   } catch (err) {
     console.error(err);
     res.status(400).send('Error');

--- a/frontend/src/pages/SearchResultsPage.tsx
+++ b/frontend/src/pages/SearchResultsPage.tsx
@@ -1,10 +1,9 @@
-import { Box, Container, Typography, Grid, makeStyles } from '@material-ui/core';
+import { Container, Typography, makeStyles } from '@material-ui/core';
 import React, { ReactElement, useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { get } from '../utils/call';
-import { LandlordOrApartmentWithLabel, LandlordWithLabel } from '../../../common/types/db-types';
-import LandlordCard from '../components/LandlordCard/LandlordCard';
 import { colors } from '../colors';
+import { CardData } from '../App';
 
 const useStyles = makeStyles({
   landlordTitle: {
@@ -18,39 +17,17 @@ const useStyles = makeStyles({
 });
 const SearchResultsPage = (): ReactElement => {
   const location = useLocation();
-  const [searchResults, setSearchResults] = useState<LandlordOrApartmentWithLabel[]>([]);
+  const [searchResults, setSearchResults] = useState<CardData[]>([]);
   const query = location.search.substring(3);
   const { landlordTitle } = useStyles();
 
-  useEffect(() => {
-    get<LandlordOrApartmentWithLabel[]>(`/search?q=${query}`, {
-      callback: (data) => {
-        setSearchResults(data);
-      },
-    });
-  }, [query]);
+  useEffect(() => {}, [query]);
 
-  // if properties is in searchItem, then it has the LandlordWithLabel type
-  function isLandlord(searchItem: LandlordOrApartmentWithLabel): searchItem is LandlordWithLabel {
-    return 'properties' in searchItem;
-  }
-  const landlordSearchResults: LandlordWithLabel[] = searchResults.filter(isLandlord).slice(0, 3);
   return (
     <Container>
-      <Box pb={5}>
-        <Box pb={2}>
-          <Typography variant="h5" align="left" className={landlordTitle}>
-            Landlords
-          </Typography>
-        </Box>
-        <Grid container spacing={2}>
-          {landlordSearchResults.map((landlordSearchResult) => (
-            <Grid item xs={4} md={4}>
-              <LandlordCard landlordData={landlordSearchResult} />
-            </Grid>
-          ))}
-        </Grid>
-      </Box>
+      <Typography variant="h5" align="left" className={landlordTitle}>
+        Landlords
+      </Typography>
     </Container>
   );
 };

--- a/frontend/src/pages/SearchResultsPage.tsx
+++ b/frontend/src/pages/SearchResultsPage.tsx
@@ -10,7 +10,7 @@ const useStyles = makeStyles({
   searchText: {
     color: colors.black,
     fontWeight: 600,
-    fontSize: 30,
+    fontSize: 35,
     margin: '0.5em 0 0.5em 0',
   },
 });

--- a/frontend/src/pages/SearchResultsPage.tsx
+++ b/frontend/src/pages/SearchResultsPage.tsx
@@ -4,6 +4,7 @@ import { useLocation } from 'react-router-dom';
 import { get } from '../utils/call';
 import { colors } from '../colors';
 import { CardData } from '../App';
+import ApartmentCards from '../components/ApartmentCard/ApartmentCards';
 
 const useStyles = makeStyles({
   landlordTitle: {
@@ -15,19 +16,21 @@ const useStyles = makeStyles({
     backgroundColor: colors.landlordCardRed,
   },
 });
+
 const SearchResultsPage = (): ReactElement => {
   const location = useLocation();
   const [searchResults, setSearchResults] = useState<CardData[]>([]);
   const query = location.search.substring(3);
-  const { landlordTitle } = useStyles();
 
-  useEffect(() => {}, [query]);
+  useEffect(() => {
+    get<CardData[]>(`/search-results?q=${query}`, {
+      callback: setSearchResults,
+    });
+  }, [query]);
 
   return (
     <Container>
-      <Typography variant="h5" align="left" className={landlordTitle}>
-        Landlords
-      </Typography>
+      <ApartmentCards data={searchResults} />
     </Container>
   );
 };

--- a/frontend/src/pages/SearchResultsPage.tsx
+++ b/frontend/src/pages/SearchResultsPage.tsx
@@ -7,17 +7,16 @@ import { CardData } from '../App';
 import ApartmentCards from '../components/ApartmentCard/ApartmentCards';
 
 const useStyles = makeStyles({
-  landlordTitle: {
+  searchText: {
+    color: colors.black,
     fontWeight: 600,
-  },
-  card: {
-    height: '100%',
-    borderRadius: '10px',
-    backgroundColor: colors.landlordCardRed,
+    fontSize: 30,
+    margin: '0.5em 0 0.5em 0',
   },
 });
 
 const SearchResultsPage = (): ReactElement => {
+  const classes = useStyles();
   const location = useLocation();
   const [searchResults, setSearchResults] = useState<CardData[]>([]);
   const query = location.search.substring(3);
@@ -30,6 +29,7 @@ const SearchResultsPage = (): ReactElement => {
 
   return (
     <Container>
+      <Typography className={classes.searchText}>Search Results For "{query}"</Typography>
       <ApartmentCards data={searchResults} />
     </Container>
   );


### PR DESCRIPTION
### Summary <!-- Required -->

Handles Issue #184 
_*This PR is a modified copy of PR #202 which had merge conflicts with package.json*_

This PR allows apartment results to be displayed when a user searches a keyword. The previous, now closed, PR #191, used the same `/search` route as before (which returns AptOrLandlord results) and filtered the returned results to contain only apartments, then required a complex type conversion. Now, this new PR creates a new route that retrieves only apartment data from the query and returns the results with all the required data in a form that can be directly used in frontend.

This PR does the following:
- remove the landlord cards from the SearchResultsPage
- create a new route `/search-results` that returns apartments that match the search query as a pageData object
- renders the returned results as ApartmentCards in SearchResultsPage

### Test Plan <!-- Required -->

Tested locally by passing different queries into the search bar and examining the returned results.

![image](https://user-images.githubusercontent.com/75141596/200135824-da2a5560-2fdb-4222-9c68-10354a166bc1.png)
![image](https://user-images.githubusercontent.com/75141596/200135833-b9685bfc-590e-4c84-8e90-5096d451d59b.png)
