### PR TITLE
Add 'status' property to Review type

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -50,7 +50,7 @@ app.post('/new-review', authenticate, async (req, res) => {
     if (review.overallRating === 0 || review.reviewText === '') {
       res.status(401).send('Error: missing fields');
     }
-    doc.set({ ...review, date: new Date(review.date), likes: 0 });
+    doc.set({ ...review, date: new Date(review.date), likes: 0, status: 'PENDING' });
     res.status(201).send(doc.id);
   } catch (err) {
     console.error(err);

--- a/common/types/db-types.ts
+++ b/common/types/db-types.ts
@@ -22,6 +22,7 @@ export type Review = {
   readonly overallRating: number;
   readonly photos: readonly string[];
   readonly reviewText: string;
+  readonly status?: 'PENDING' | 'APPROVED' | 'DECLINED';
 };
 
 export type ReviewWithId = Review & Id;


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request is the first step in preparing for an admin page and report abuse button.

- added 'status' property to Review type with possible values being one of PENDING, APPROVED, DECLINED
- added default status of PENDING when creating a new review in the '/new-review' endpoint

### Test Plan <!-- Required -->
I created a test review and confirmed that the status property was set to PENDING in Firestore.
<!-- Provide screenshots or point out the additional unit tests -->