### PR TITLE
Realigned home drop down button when resizing window

### DIFF
--- a/frontend/src/components/utils/NavBar/index.tsx
+++ b/frontend/src/components/utils/NavBar/index.tsx
@@ -104,7 +104,7 @@ const useStyles = makeStyles(() => ({
   menuDrawer: {
     alignSelf: 'right',
     marginBottom: '8px',
-    marginLeft: '50%',
+    marginLeft: '70%',
   },
   drawerButton: {
     fontFamily: 'Work Sans, sans-serif',


### PR DESCRIPTION
### Summary

This pull request fixed the issue of the menu drawer not aligning correctly when the window is made smaller. The menu drawer is now closer to the right margin.

- Fixed menu drawer position bug.

### Test Plan

<img width="766" alt="Screen Shot 2023-03-19 at 16 53 11" src="https://user-images.githubusercontent.com/125820523/226208556-c6f877e1-7aed-4288-8fbd-da9620fadfb1.png">

### Notes