### PR TITLE
Fix screen freeze after signing in from report abuse button

### DIFF
--- a/frontend/src/components/Review/Review.tsx
+++ b/frontend/src/components/Review/Review.tsx
@@ -88,11 +88,20 @@ const ReviewComponent = ({
     ];
   };
 
-  const handleReportAbuse = async (reviewId: string) => {
+  const reportAbuseHanler = async (reviewId: string) => {
     if (user) {
       const endpoint = `update-review-status/${reviewId}/PENDING`;
       await axios.put(endpoint);
       setToggle((cur) => !cur);
+    } else {
+      let user = await getUser(true);
+      setUser(user);
+    }
+  };
+
+  const likeHandler = async (id: string) => {
+    if (user) {
+      (liked ? removeLike : addLike)(id);
     } else {
       let user = await getUser(true);
       setUser(user);
@@ -168,7 +177,7 @@ const ReviewComponent = ({
           <Grid item>
             <Button
               color={liked ? 'primary' : 'default'}
-              onClick={() => (liked ? removeLike : addLike)(id)}
+              onClick={() => likeHandler(id)}
               className={button}
               size="small"
               disabled={likeLoading}
@@ -177,7 +186,7 @@ const ReviewComponent = ({
             </Button>
           </Grid>
           <Grid item>
-            <Button onClick={() => handleReportAbuse(review.id)} className={button} size="small">
+            <Button onClick={() => reportAbuseHanler(review.id)} className={button} size="small">
               Report Abuse
             </Button>
           </Grid>

--- a/frontend/src/components/Review/Review.tsx
+++ b/frontend/src/components/Review/Review.tsx
@@ -91,15 +91,14 @@ const ReviewComponent = ({
   };
 
   const handleReportAbuse = async (reviewId: string) => {
-    let user = await getUser(true);
-    setUser(user);
-    if (!user) {
-      return;
+    if (user) {
+      const endpoint = `update-review-status/${reviewId}/PENDING`;
+      await axios.put(endpoint);
+      setToggle(!toggle);
+    } else {
+      let user = await getUser(true);
+      setUser(user);
     }
-
-    const endpoint = `update-review-status/${reviewId}/PENDING`;
-    await axios.put(endpoint);
-    setToggle(!toggle);
   };
 
   return (

--- a/frontend/src/components/Review/Review.tsx
+++ b/frontend/src/components/Review/Review.tsx
@@ -91,12 +91,10 @@ const ReviewComponent = ({
   };
 
   const handleReportAbuse = async (reviewId: string) => {
+    let user = await getUser(true);
+    setUser(user);
     if (!user) {
-      let user = await getUser(true);
-      setUser(user);
-    }
-    if (!user) {
-      throw new Error('Failed to login');
+      return;
     }
 
     const endpoint = `update-review-status/${reviewId}/PENDING`;


### PR DESCRIPTION
### Summary <!-- Required -->

When a user is not signed in, clicking Report Abuse from an apartment/landlord page will prompt them to sign in. Previously, when returning to the page, it would freeze, and nothing would be clickable. 

* prompt for sign in
* force user to click Report Abuse again after signing if desired

### Test Plan <!-- Required -->
After returning to page, user can successfully perform all available actions, such as leave a review
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/69334328/226777775-50fe11b3-728e-4ae5-b914-782c1de68429.png">


