### PR TITLE
Display all review images instead of 1

### DIFF
--- a/frontend/src/components/Review/Review.tsx
+++ b/frontend/src/components/Review/Review.tsx
@@ -55,6 +55,18 @@ const useStyles = makeStyles(() => ({
       color: 'inherit',
     },
   },
+  photoStyle: {
+    borderRadius: '4px',
+    width: '32%',
+    height: '16vw',
+  },
+  photoRowStyle: {
+    display: 'flex',
+    lexDirection: 'row',
+    gap: '1vw',
+    paddingTop: '2%',
+    paddingLeft: '0.6%',
+  },
 }));
 
 const ReviewComponent = ({
@@ -69,7 +81,7 @@ const ReviewComponent = ({
 }: Props): ReactElement => {
   const { id, detailedRatings, overallRating, date, reviewText, likes, photos } = review;
   const formattedDate = format(new Date(date), 'MMM dd, yyyy').toUpperCase();
-  const { root, expand, expandOpen, dateText, button } = useStyles();
+  const { root, expand, expandOpen, dateText, button, photoStyle, photoRowStyle } = useStyles();
   const [expanded, setExpanded] = useState(false);
   const [expandedText, setExpandedText] = useState(false);
 
@@ -157,14 +169,19 @@ const ReviewComponent = ({
                 </Typography>
               </Grid>
               {photos.length > 0 && (
-                <Grid container alignItems="center" justifyContent="center">
-                  <Grid item xs={12} sm={6}>
-                    <CardMedia
-                      component="img"
-                      alt="Apt image"
-                      image={photos[0]}
-                      title="Apt image"
-                    />
+                <Grid container>
+                  <Grid item className={photoRowStyle}>
+                    {photos.map((photo) => {
+                      return (
+                        <CardMedia
+                          component="img"
+                          alt="Apt image"
+                          image={photo}
+                          title="Apt image"
+                          className={photoStyle}
+                        />
+                      );
+                    })}
                   </Grid>
                 </Grid>
               )}

--- a/frontend/src/components/Review/Review.tsx
+++ b/frontend/src/components/Review/Review.tsx
@@ -57,7 +57,7 @@ const useStyles = makeStyles(() => ({
   },
   photoStyle: {
     borderRadius: '4px',
-    width: '32%',
+    width: '17vw',
     height: '16vw',
   },
   photoRowStyle: {


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request displays all the images the user uploads to a review, unlike how previously only 1 image was displayed. 

- [x] fixed frontend bug where only 1 image was displayed in each review

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
1 and 2 pictures:
<img width="1421" alt="Screen Shot 2023-03-26 at 20 54 24" src="https://user-images.githubusercontent.com/125820523/227816575-c9d1f379-66ea-4b1b-b3ae-87c2f259dabe.png">
3 pictures:
<img width="1409" alt="Screen Shot 2023-03-26 at 20 54 10" src="https://user-images.githubusercontent.com/125820523/227816612-bead696b-bf69-4d3d-9452-8a8462c88083.png">