### PR TITLE
Adapt picture styling for admin page

### DIFF
--- a/frontend/src/components/Admin/AdminReview.tsx
+++ b/frontend/src/components/Admin/AdminReview.tsx
@@ -46,12 +46,25 @@ const useStyles = makeStyles(() => ({
     marginTop: '10px',
     marginBottom: '30px',
   },
+  photoStyle: {
+    borderRadius: '4px',
+    height: '15em',
+    width: '15em',
+  },
+  photoRowStyle: {
+    overflowX: 'auto',
+    display: 'flex',
+    lexDirection: 'row',
+    gap: '1vw',
+    paddingTop: '2%',
+    paddingLeft: '0.6%',
+  },
 }));
 
 const AdminReviewComponent = ({ review, setToggle }: Props): ReactElement => {
   const { detailedRatings, overallRating, date, reviewText, photos } = review;
   const formattedDate = format(new Date(date), 'MMM dd, yyyy').toUpperCase();
-  const { root, dateText, ratingInfo } = useStyles();
+  const { root, dateText, ratingInfo, photoStyle, photoRowStyle } = useStyles();
   const [apt, setApt] = useState<ApartmentWithId[]>([]);
   const [landlord, setLandlord] = useState<Landlord>();
 
@@ -133,14 +146,19 @@ const AdminReviewComponent = ({ review, setToggle }: Props): ReactElement => {
               </Grid>
 
               {photos.length > 0 && (
-                <Grid container alignItems="center" justifyContent="center">
-                  <Grid item xs={12} sm={6}>
-                    <CardMedia
-                      component="img"
-                      alt="Apt image"
-                      image={photos[0]}
-                      title="Apt image"
-                    />
+                <Grid container>
+                  <Grid item className={photoRowStyle}>
+                    {photos.map((photo) => {
+                      return (
+                        <CardMedia
+                          component="img"
+                          alt="Apt image"
+                          image={photo}
+                          title="Apt image"
+                          className={photoStyle}
+                        />
+                      );
+                    })}
                   </Grid>
                 </Grid>
               )}


### PR DESCRIPTION
Old:
<img width="1294" alt="Screenshot 2023-03-31 at 4 22 37 PM" src="https://user-images.githubusercontent.com/62644357/229222431-8572555c-251d-49cb-be20-f9e5281e87f1.png">


New:
<img width="1390" alt="Screenshot 2023-03-31 at 4 22 31 PM" src="https://user-images.githubusercontent.com/62644357/229222440-6834d60d-0ec2-46ef-a8a5-2b956f646324.png">
