### PR TITLE
Mobile view for search results

### DIFF
--- a/frontend/src/components/ApartmentCard/ApartmentCard.tsx
+++ b/frontend/src/components/ApartmentCard/ApartmentCard.tsx
@@ -36,12 +36,13 @@ const useStyles = makeStyles({
     fontWeight: 800,
   },
   marginTxt: {
-    paddingLeft: '30px',
+    paddingBottom: '-10px',
+    paddingLeft: '20px',
   },
   reviewNum: {
     fontWeight: 700,
     marginLeft: '10px',
-    fontSize: '15px',
+    fontSize: '18px',
   },
   textStyle: {
     maxWidth: '100%',
@@ -54,14 +55,11 @@ const useStyles = makeStyles({
     marginRight: '5px',
   },
   imgMobile: {
-    borderRadius: '12px',
-    width: '100%',
-    objectFit: 'cover',
+    borderRadius: '10px',
+    marginTop: '13px',
   },
   imgContainerMobile: {
     borderRadius: '10px',
-    padding: '22px',
-    paddingBottom: '7px',
   },
 });
 
@@ -113,13 +111,22 @@ const ApartmentCard = ({ buildingData, numReviews, company }: Props): ReactEleme
         <Grid item sm={8} md={10} className={marginTxt}>
           <CardContent>
             <Grid container>
-              <Typography variant="h5" className={aptNameTxt}>
+              <Typography
+                variant="h5"
+                className={aptNameTxt}
+                style={{ fontSize: isMobile ? '20px' : '25px' }}
+              >
                 {name}
               </Typography>
               {company && (
                 <Grid container item justifyContent="space-between">
                   <Grid>
-                    <Typography variant="subtitle1">{buildingData.address}</Typography>
+                    <Typography
+                      variant="subtitle1"
+                      style={{ fontSize: isMobile ? '15px' : '20px' }}
+                    >
+                      {buildingData.address}
+                    </Typography>
                   </Grid>
                 </Grid>
               )}
@@ -129,7 +136,6 @@ const ApartmentCard = ({ buildingData, numReviews, company }: Props): ReactEleme
                   {numReviews + (numReviews !== 1 ? ' Reviews' : ' Review')}
                 </Typography>
               </Grid>
-
               {!isMobile && (
                 <Grid>
                   <Typography variant="subtitle1" className={textStyle}>

--- a/frontend/src/components/ApartmentCard/ApartmentCard.tsx
+++ b/frontend/src/components/ApartmentCard/ApartmentCard.tsx
@@ -20,6 +20,7 @@ type Props = {
   numReviews: number;
   company?: string;
 };
+
 const useStyles = makeStyles({
   root: {
     borderRadius: '10px',
@@ -31,24 +32,16 @@ const useStyles = makeStyles({
     borderRadius: '12%',
     padding: '17px',
   },
-  imgMobile: {
-    borderRadius: '8%',
-    height: '480px',
-    width: '100%',
-    padding: '20px',
-  },
-
   aptNameTxt: {
     fontWeight: 800,
-    marginLeft: '25px',
   },
   marginTxt: {
-    marginLeft: '25px',
+    paddingLeft: '30px',
   },
-
   reviewNum: {
     fontWeight: 700,
     marginLeft: '10px',
+    fontSize: '15px',
   },
   textStyle: {
     maxWidth: '100%',
@@ -57,27 +50,38 @@ const useStyles = makeStyles({
     WebkitLineClamp: 3,
     overflow: 'hidden',
     textOverflow: 'ellipsis',
-    marginLeft: '25px',
+    marginLeft: '3px',
     marginRight: '5px',
+  },
+  imgMobile: {
+    borderRadius: '12px',
+    width: '100%',
+    objectFit: 'cover',
+  },
+  imgContainerMobile: {
+    borderRadius: '10px',
+    padding: '22px',
+    paddingBottom: '7px',
   },
 });
 
 const ApartmentCard = ({ buildingData, numReviews, company }: Props): ReactElement => {
   const { id, name, photos } = buildingData;
   const img = photos.length > 0 ? photos[0] : ApartmentImg;
+  const isMobile = useMediaQuery('(max-width:600px)');
+  const [reviewList, setReviewList] = useState<ReviewWithId[]>([]);
+  const sampleReview = reviewList.length === 0 ? '' : reviewList[0].reviewText;
+
   const {
     imgStyle,
     imgMobile,
     aptNameTxt,
     marginTxt,
     root,
-
     reviewNum,
     textStyle,
+    imgContainerMobile,
   } = useStyles();
-  const matches = useMediaQuery('(min-width:600px)');
-  const [reviewList, setReviewList] = useState<ReviewWithId[]>([]);
-  const sampleReview = reviewList.length === 0 ? 'No Reviews' : reviewList[0].reviewText;
 
   useEffect(() => {
     get<ReviewWithId[]>(`/review/aptId/${id}/APPROVED`, {
@@ -88,45 +92,51 @@ const ApartmentCard = ({ buildingData, numReviews, company }: Props): ReactEleme
   return (
     <Card className={root} variant="outlined">
       <Grid container direction="row" alignItems="center">
-        {matches && (
+        {!isMobile && (
           <Grid item xs={11} sm={4} md={2}>
             <CardMedia className={imgStyle} image={img} component="img" title={name} />
           </Grid>
         )}
-        {!matches && (
-          <Grid item xs={11} sm={4} md={2}>
-            <CardMedia className={imgMobile} image={img} component="img" title={name} />
+        {isMobile && (
+          <Grid container direction="row" alignItems="center" justifyContent="center">
+            <Grid item xs={11} sm={4} md={2} className={imgContainerMobile}>
+              <CardMedia
+                className={imgMobile}
+                style={{ height: isMobile ? '160px' : '480px' }}
+                image={img}
+                component="img"
+                title={name}
+              />
+            </Grid>
           </Grid>
         )}
-        <Grid item sm={8} md={10}>
+        <Grid item sm={8} md={10} className={marginTxt}>
           <CardContent>
-            <Grid container spacing={1}>
-              <Grid item>
-                <Typography variant="h5" className={aptNameTxt}>
-                  {name}
-                </Typography>
-              </Grid>
+            <Grid container>
+              <Typography variant="h5" className={aptNameTxt}>
+                {name}
+              </Typography>
               {company && (
-                <Grid container item justifyContent="space-between" className={marginTxt}>
+                <Grid container item justifyContent="space-between">
                   <Grid>
                     <Typography variant="subtitle1">{buildingData.address}</Typography>
                   </Grid>
                 </Grid>
               )}
-              <Grid container direction="row" alignItems="center" className={marginTxt}>
+              <Grid container direction="row" alignItems="center">
                 <HeartRating value={getAverageRating(reviewList)} precision={0.5} readOnly />
                 <Typography variant="h6" className={reviewNum}>
                   {numReviews + (numReviews !== 1 ? ' Reviews' : ' Review')}
                 </Typography>
               </Grid>
 
-              <Grid>
-                {matches && (
+              {!isMobile && (
+                <Grid>
                   <Typography variant="subtitle1" className={textStyle}>
                     {sampleReview}
                   </Typography>
-                )}
-              </Grid>
+                </Grid>
+              )}
             </Grid>
           </CardContent>
         </Grid>

--- a/frontend/src/components/ApartmentCard/ApartmentCards.tsx
+++ b/frontend/src/components/ApartmentCard/ApartmentCards.tsx
@@ -10,7 +10,7 @@ type Props = {
 
 const useStyles = makeStyles({
   boundingBox: {
-    marginTop: '2em',
+    marginTop: '0.2em',
     marginBottom: '2em',
   },
   showMoreButton: {

--- a/frontend/src/components/ApartmentCard/ApartmentCards.tsx
+++ b/frontend/src/components/ApartmentCard/ApartmentCards.tsx
@@ -1,6 +1,6 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useState, useEffect } from 'react';
 import ApartmentCard from './ApartmentCard';
-import { Grid, Link, makeStyles } from '@material-ui/core';
+import { Grid, Link, makeStyles, Button, useMediaQuery } from '@material-ui/core';
 import { Link as RouterLink } from 'react-router-dom';
 import { CardData } from '../../App';
 
@@ -13,36 +13,81 @@ const useStyles = makeStyles({
     marginTop: '2em',
     marginBottom: '2em',
   },
+  showMoreButton: {
+    border: '1px solid #A3A3A3',
+    borderRadius: '9px',
+    color: '#000000B2',
+    width: '10em',
+    textTransform: 'initial',
+  },
+  horizontalLine: {
+    borderTop: '1px solid #C4C4C4',
+    width: '95%',
+    margin: '16px auto',
+    borderLeft: 'none',
+    borderRight: 'none',
+    borderBottom: 'none',
+  },
 });
 
 const ApartmentCards = ({ data }: Props): ReactElement => {
-  const { boundingBox } = useStyles();
+  const { boundingBox, showMoreButton, horizontalLine } = useStyles();
+  const isMobile = useMediaQuery('(max-width:600px)');
+
+  const [resultsToShow, setResultsToShow] = useState<number>(data.length);
+
+  useEffect(() => {
+    if (isMobile) {
+      setResultsToShow(5);
+    } else {
+      setResultsToShow(data.length);
+    }
+  }, [isMobile, data.length]);
+
+  const handleShowMore = () => {
+    setResultsToShow(resultsToShow + 5);
+  };
 
   return (
-    <Grid container spacing={3} className={boundingBox}>
-      {data &&
-        data.map(({ buildingData, numReviews, company }, index) => {
-          const { id } = buildingData;
-          return (
-            <Grid item md={12} key={index}>
-              <Link
-                {...{
-                  to: `/apartment/${id}`,
-                  style: { textDecoration: 'none' },
-                  component: RouterLink,
-                }}
-              >
-                <ApartmentCard
-                  key={index}
-                  numReviews={numReviews}
-                  buildingData={buildingData}
-                  company={company}
-                />
-              </Link>
+    <>
+      <Grid container spacing={3} className={boundingBox}>
+        {data &&
+          data.slice(0, resultsToShow).map(({ buildingData, numReviews, company }, index) => {
+            const { id } = buildingData;
+            return (
+              <Grid item md={12} key={index}>
+                <Link
+                  {...{
+                    to: `/apartment/${id}`,
+                    style: { textDecoration: 'none' },
+                    component: RouterLink,
+                  }}
+                >
+                  <ApartmentCard
+                    key={index}
+                    numReviews={numReviews}
+                    buildingData={buildingData}
+                    company={company}
+                  />
+                </Link>
+              </Grid>
+            );
+          })}
+
+        {isMobile && data && data.length > resultsToShow && (
+          <>
+            <Grid item xs={12}>
+              <hr className={horizontalLine} />
             </Grid>
-          );
-        })}
-    </Grid>
+            <Grid item xs={12} container justifyContent="center">
+              <Button className={showMoreButton} onClick={handleShowMore}>
+                Show more
+              </Button>
+            </Grid>
+          </>
+        )}
+      </Grid>
+    </>
   );
 };
 

--- a/frontend/src/pages/SearchResultsPage.tsx
+++ b/frontend/src/pages/SearchResultsPage.tsx
@@ -1,4 +1,4 @@
-import { Container, Typography, makeStyles } from '@material-ui/core';
+import { Container, Typography, makeStyles, useMediaQuery } from '@material-ui/core';
 import React, { ReactElement, useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { get } from '../utils/call';
@@ -10,16 +10,15 @@ const useStyles = makeStyles({
   searchText: {
     color: colors.black,
     fontWeight: 500,
-    fontSize: 30,
-    margin: '0.5em 0 0.5em 0',
   },
 });
 
 const SearchResultsPage = (): ReactElement => {
-  const classes = useStyles();
+  const { searchText } = useStyles();
   const location = useLocation();
   const [searchResults, setSearchResults] = useState<CardData[]>([]);
   const query = location.search.substring(3);
+  const isMobile = useMediaQuery('(max-width:600px)');
 
   useEffect(() => {
     get<CardData[]>(`/search-results?q=${query}`, {
@@ -29,7 +28,9 @@ const SearchResultsPage = (): ReactElement => {
 
   return (
     <Container>
-      <Typography className={classes.searchText}>Search results for "{query}"</Typography>
+      <Typography className={searchText} style={{ fontSize: isMobile ? '20px' : '30px' }}>
+        Search results for "{query}"
+      </Typography>
       <ApartmentCards data={searchResults} />
     </Container>
   );


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request implements the mobile view of the search results page [https://www.figma.com/file/rUX3wOgAaZ40GWf5HwMTkV/CUAPTS-SP'23?node-id=184-2800&t=vRSxVvh2YIUUS9aU-0](url)

* changed layout of ApartmentCard
* only show new 5 results at a time, with a `Show more` button at the bottom of the page

### Test Plan <!-- Required -->

**Top of search results**
<img width="374" alt="image" src="https://user-images.githubusercontent.com/69334328/229249912-a7908979-d66a-44a7-b05a-cf7f5d4d5842.png">

**Bottom of search results**
<img width="373" alt="image" src="https://user-images.githubusercontent.com/69334328/229249929-1e25cb43-a85b-4c76-9dc4-3762b2e5ea6f.png">

**After clicking on the show more button**
<img width="372" alt="image" src="https://user-images.githubusercontent.com/69334328/229249944-d6293e50-a67f-41d6-9ca4-4b79d0919182.png">


