### PR TITLE
Implemented Search Bar Redesign

### DIFF
--- a/frontend/src/components/Home/Autocomplete.tsx
+++ b/frontend/src/components/Home/Autocomplete.tsx
@@ -133,65 +133,6 @@ const Autocomplete = ({ drawerOpen, setDrawerOpen }: Props): ReactElement => {
     }
   };
 
-  const Menu = () => {
-    return (
-      <div>
-        <ClickAwayListener
-          onClickAway={() => {
-            setOpen(false);
-          }}
-        >
-          <div>
-            {open ? (
-              <MenuList
-                style={{ width: `${inputRef.current?.offsetWidth}px`, zIndex: 1 }}
-                className={menuList}
-                autoFocusItem={focus}
-                onKeyDown={handleListKeyDown}
-              >
-                {options.length === 0 ? (
-                  <MenuItem disabled>No search results.</MenuItem>
-                ) : (
-                  options.map(({ id, name, address, label }, index) => {
-                    return (
-                      <Link
-                        key={index}
-                        {...{
-                          to: `/${label.toLowerCase()}/${id}`,
-                          style: { textDecoration: 'none' },
-                          component: RouterLink,
-                        }}
-                      >
-                        <MenuItem button={true} key={index} onClick={() => setOpen(false)}>
-                          <Grid container justifyContent="space-between">
-                            <Grid item xl={8}>
-                              <Typography className={buildingText}>{name}</Typography>
-
-                              <Typography className={addressText}>
-                                {address !== name && address}
-                              </Typography>
-                            </Grid>
-                            <Grid item xl={4}>
-                              <Chip
-                                color="primary"
-                                label={label.toLowerCase()}
-                                className={resultChip}
-                              />
-                            </Grid>
-                          </Grid>
-                        </MenuItem>
-                      </Link>
-                    );
-                  })
-                )}
-              </MenuList>
-            ) : null}
-          </div>
-        </ClickAwayListener>
-      </div>
-    );
-  };
-
   useEffect(() => {
     if (query === '') {
       setOpen(false);

--- a/frontend/src/components/Home/Autocomplete.tsx
+++ b/frontend/src/components/Home/Autocomplete.tsx
@@ -133,6 +133,65 @@ const Autocomplete = ({ drawerOpen, setDrawerOpen }: Props): ReactElement => {
     }
   };
 
+  const Menu = () => {
+    return (
+      <div>
+        <ClickAwayListener
+          onClickAway={() => {
+            setOpen(false);
+          }}
+        >
+          <div>
+            {open ? (
+              <MenuList
+                style={{ width: `${inputRef.current?.offsetWidth}px`, zIndex: 1 }}
+                className={menuList}
+                autoFocusItem={focus}
+                onKeyDown={handleListKeyDown}
+              >
+                {options.length === 0 ? (
+                  <MenuItem disabled>No search results.</MenuItem>
+                ) : (
+                  options.map(({ id, name, address, label }, index) => {
+                    return (
+                      <Link
+                        key={index}
+                        {...{
+                          to: `/${label.toLowerCase()}/${id}`,
+                          style: { textDecoration: 'none' },
+                          component: RouterLink,
+                        }}
+                      >
+                        <MenuItem button={true} key={index} onClick={() => setOpen(false)}>
+                          <Grid container justifyContent="space-between">
+                            <Grid item xl={8}>
+                              <Typography className={buildingText}>{name}</Typography>
+
+                              <Typography className={addressText}>
+                                {address !== name && address}
+                              </Typography>
+                            </Grid>
+                            <Grid item xl={4}>
+                              <Chip
+                                color="primary"
+                                label={label.toLowerCase()}
+                                className={resultChip}
+                              />
+                            </Grid>
+                          </Grid>
+                        </MenuItem>
+                      </Link>
+                    );
+                  })
+                )}
+              </MenuList>
+            ) : null}
+          </div>
+        </ClickAwayListener>
+      </div>
+    );
+  };
+
   useEffect(() => {
     if (query === '') {
       setOpen(false);

--- a/frontend/src/components/Home/Autocomplete.tsx
+++ b/frontend/src/components/Home/Autocomplete.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, { ReactElement, useEffect, useState, useRef } from 'react';
 import { useLocation } from 'react-router-dom';
 import {
   Chip,
@@ -19,7 +19,12 @@ import { Link as RouterLink } from 'react-router-dom';
 import { colors } from '../../colors';
 import { useHistory } from 'react-router-dom';
 
-export default function Autocomplete() {
+type Props = {
+  drawerOpen: boolean;
+  setDrawerOpen: React.Dispatch<React.SetStateAction<boolean>>;
+};
+
+const Autocomplete = ({ drawerOpen, setDrawerOpen }: Props): ReactElement => {
   const [isMobile, setIsMobile] = useState<boolean>(false);
   const useStyles = makeStyles((theme) => ({
     menuList: {
@@ -39,6 +44,9 @@ export default function Autocomplete() {
     buildingText: {
       color: colors.black,
     },
+    homeSearchIcon: {
+      paddingRight: '10px',
+    },
     searchIcon: {
       display: 'flex',
       alignItems: 'center',
@@ -51,7 +59,7 @@ export default function Autocomplete() {
     searchIconBackground: {
       backgroundColor: colors.red1,
       width: '50px',
-      height: isMobile ? '35px' : '50px',
+      height: isMobile ? '35px' : '45px',
       position: 'absolute',
       right: '0',
       borderRadius: '0px 10px 10px 0px',
@@ -62,18 +70,18 @@ export default function Autocomplete() {
     resultChip: { cursor: 'pointer' },
     field: {
       '&.Mui-focused': {
-        border: '20px black ',
         '& .MuiOutlinedInput-notchedOutline': {
-          border: 'none',
+          border: `1px solid #c4c4c4`,
         },
       },
-      height: isMobile ? '35px' : '50px',
+      height: isMobile ? '35px' : '45px',
     },
   }));
   const {
     menuList,
     text,
     searchIcon,
+    homeSearchIcon,
     searchIconBackground,
     resultChip,
     field,
@@ -221,13 +229,47 @@ export default function Autocomplete() {
   }, [loading, query]);
 
   const location = useLocation();
-  let placeholderText = '';
-  if (location.pathname === '/') {
-    placeholderText = 'Search by any location e.g. “301 College Ave”';
-  }
+  let placeholderText =
+    location.pathname === '/' && !drawerOpen
+      ? 'Search by any location e.g. “301 College Ave”'
+      : 'Search';
+
+  /**
+   * @returns The the InputProps for the search bar depending on user's location.
+   * If: home and NavBar drawer is closed –> returns search bar style without red input adornment on right.
+   * If: home/NavBar drawer is open –> returns search bar style with red input adornment on right.
+   */
+  const getInputProps = () => {
+    if (location.pathname === '/' && !drawerOpen) {
+      return {
+        style: { fontSize: isMobile ? 16 : 20 },
+        endAdornment: <>{loading ? <CircularProgress color="inherit" size={20} /> : null}</>,
+        startAdornment: (
+          <SearchIcon
+            style={{ fontSize: isMobile ? 17 : 22, marginLeft: isMobile ? -3 : 0 }}
+            className={homeSearchIcon}
+          />
+        ),
+        className: field,
+      };
+    } else {
+      return {
+        style: { height: isMobile ? '35px' : '45px', borderRadius: '10px' },
+        endAdornment: (
+          <React.Fragment>
+            {loading ? <CircularProgress color="inherit" size={20} /> : null}
+            <div className={searchIconBackground}>
+              <SearchIcon className={searchIcon} />
+            </div>
+          </React.Fragment>
+        ),
+        className: field,
+      };
+    }
+  };
 
   return (
-    <div style={{ position: 'relative' }}>
+    <div style={{ position: 'relative', width: drawerOpen ? '100%' : '65%' }}>
       <TextField
         fullWidth
         ref={inputRef}
@@ -237,7 +279,7 @@ export default function Autocomplete() {
         variant="outlined"
         style={{
           borderRadius: '10px',
-          width: !isMobile ? '65%' : '98%',
+          width: !isMobile ? '100%' : '98%',
         }}
         onKeyDown={textFieldHandleListKeyDown}
         onChange={(event) => {
@@ -246,19 +288,10 @@ export default function Autocomplete() {
             handleOnChange(value);
           }
         }}
-        InputProps={{
-          style: { height: isMobile ? '35px' : '50px', borderRadius: '10px' },
-          endAdornment: (
-            <React.Fragment>
-              {loading ? <CircularProgress color="inherit" size={20} /> : null}
-              <div className={searchIconBackground}>
-                <SearchIcon className={searchIcon} />
-              </div>
-            </React.Fragment>
-          ),
-          className: field,
-        }}
+        InputProps={getInputProps()}
       />
     </div>
   );
-}
+};
+
+export default Autocomplete;

--- a/frontend/src/components/Home/Autocomplete.tsx
+++ b/frontend/src/components/Home/Autocomplete.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, useRef } from 'react';
+import { useLocation } from 'react-router-dom';
 import {
   Chip,
   CircularProgress,
@@ -38,7 +39,26 @@ export default function Autocomplete() {
     buildingText: {
       color: colors.black,
     },
-    searchIcon: { paddingRight: '10px' },
+    searchIcon: {
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      color: 'white',
+      // fontSize: isMobile ? 17 : 22
+      height: '62%',
+      width: '62%',
+    },
+    searchIconBackground: {
+      backgroundColor: colors.red1,
+      width: '50px',
+      height: isMobile ? '35px' : '50px',
+      position: 'absolute',
+      right: '0',
+      borderRadius: '0px 10px 10px 0px',
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
     resultChip: { cursor: 'pointer' },
     field: {
       '&.Mui-focused': {
@@ -50,7 +70,16 @@ export default function Autocomplete() {
       height: isMobile ? '35px' : '50px',
     },
   }));
-  const { menuList, text, searchIcon, resultChip, field, addressText, buildingText } = useStyles();
+  const {
+    menuList,
+    text,
+    searchIcon,
+    searchIconBackground,
+    resultChip,
+    field,
+    addressText,
+    buildingText,
+  } = useStyles();
   const [focus, setFocus] = useState(false);
   const inputRef = useRef<HTMLDivElement>(document.createElement('div'));
   const [loading, setLoading] = useState(false);
@@ -191,18 +220,24 @@ export default function Autocomplete() {
     }
   }, [loading, query]);
 
+  const location = useLocation();
+  let placeholderText = '';
+  if (location.pathname === '/') {
+    placeholderText = 'Search by any location e.g. “301 College Ave”';
+  }
+
   return (
-    <div>
+    <div style={{ position: 'relative' }}>
       <TextField
         fullWidth
         ref={inputRef}
         value={query}
-        placeholder="Search by any location e.g. “301 College Ave”"
+        placeholder={placeholderText}
         className={text}
         variant="outlined"
         style={{
-          borderRadius: '6px',
-          width: !isMobile ? '70%' : '98%',
+          borderRadius: '10px',
+          width: !isMobile ? '65%' : '98%',
         }}
         onKeyDown={textFieldHandleListKeyDown}
         onChange={(event) => {
@@ -212,19 +247,18 @@ export default function Autocomplete() {
           }
         }}
         InputProps={{
-          style: { fontSize: isMobile ? 16 : 20 },
-          endAdornment: <>{loading ? <CircularProgress color="inherit" size={20} /> : null}</>,
-          startAdornment: (
-            <SearchIcon
-              style={{ fontSize: isMobile ? 17 : 22, marginLeft: isMobile ? -3 : 0 }}
-              className={searchIcon}
-            />
+          style: { height: isMobile ? '35px' : '50px', borderRadius: '10px' },
+          endAdornment: (
+            <React.Fragment>
+              {loading ? <CircularProgress color="inherit" size={20} /> : null}
+              <div className={searchIconBackground}>
+                <SearchIcon className={searchIcon} />
+              </div>
+            </React.Fragment>
           ),
           className: field,
         }}
       />
-
-      <Menu />
     </div>
   );
 }

--- a/frontend/src/components/Home/Autocomplete.tsx
+++ b/frontend/src/components/Home/Autocomplete.tsx
@@ -71,7 +71,7 @@ const Autocomplete = ({ drawerOpen, setDrawerOpen }: Props): ReactElement => {
     field: {
       '&.Mui-focused': {
         '& .MuiOutlinedInput-notchedOutline': {
-          border: `1px solid #c4c4c4`,
+          border: `1px solid ${colors.red1}`,
         },
       },
       height: isMobile ? '35px' : '45px',

--- a/frontend/src/components/utils/NavBar/index.tsx
+++ b/frontend/src/components/utils/NavBar/index.tsx
@@ -112,8 +112,9 @@ const useStyles = makeStyles(() => ({
   },
   search: {
     width: '50%',
-    marginRight: '25%',
+    marginLeft: '30px',
     marginBottom: '-15px',
+    borderRadius: '10px',
   },
   searchHidden: {
     width: '50%',
@@ -126,7 +127,8 @@ const useStyles = makeStyles(() => ({
     marginLeft: '70%',
   },
   searchDrawer: {
-    fontSize: 5,
+    // fontSize: 5,
+    width: '100%',
     marginBottom: '5%',
   },
 }));
@@ -317,16 +319,16 @@ const NavBar = ({ headersData, user, setUser }: Props): ReactElement => {
   );
 
   const searchBar = location.pathname !== '/';
-
   const displayDesktop = () => {
     return (
       <Grid container className={toolbar} alignItems="center" justifyContent="space-between">
-        <Grid item md={3}>
-          {homeLogo}
+        <Grid item md={9} container alignItems="center">
+          <Grid item>{homeLogo}</Grid>
+          <Grid item className={searchBar ? search : searchHidden}>
+            {auto()}
+          </Grid>
         </Grid>
-        <Grid item md={6} className={searchBar ? search : searchHidden}>
-          {auto()}
-        </Grid>
+
         {isAdmin(user) && (
           <Grid item md={1} className={menu} container justifyContent="flex-end">
             {getAdminButton()}
@@ -367,7 +369,9 @@ const NavBar = ({ headersData, user, setUser }: Props): ReactElement => {
             onClose: () => setDrawerOpen(false),
           }}
         >
-          <div className={drawerContainer}>{getDrawerChoices()}</div>
+          <div className={drawerContainer} style={{ width: '80%' }}>
+            {getDrawerChoices()}
+          </div>
         </Drawer>
       </Toolbar>
     );

--- a/frontend/src/components/utils/NavBar/index.tsx
+++ b/frontend/src/components/utils/NavBar/index.tsx
@@ -23,7 +23,7 @@ import { Link as RouterLink } from 'react-router-dom';
 import LogoIcon from '../../../assets/navbar-logo.svg';
 import { useLocation } from 'react-router-dom';
 import { colors } from '../../../colors';
-import auto from '../../Home/Autocomplete';
+import Autocomplete from '../../Home/Autocomplete';
 import { isAdmin } from '../../../utils/adminTool';
 
 export type NavbarButton = {
@@ -178,16 +178,23 @@ const NavBar = ({ headersData, user, setUser }: Props): ReactElement => {
   }, [user]);
 
   useEffect(() => {
-    const handleResize = () => setIsMobile(window.innerWidth <= 600);
+    const handleResize = () => {
+      setIsMobile(window.innerWidth <= 600);
+      if (drawerOpen && window.innerWidth >= 960) {
+        setDrawerOpen(false);
+      }
+    };
     handleResize();
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
-  }, []);
+  }, [drawerOpen]);
 
   const getDrawerChoices = () => {
     return (
       <ThemeProvider theme={muiTheme}>
-        <Grid className={searchDrawer}>{auto()}</Grid>
+        <Grid className={searchDrawer}>
+          <Autocomplete drawerOpen={drawerOpen} setDrawerOpen={setDrawerOpen} />
+        </Grid>
         {headersData.map(({ label, href }, index) => {
           return (
             <Link component={RouterLink} to={href} color={GetButtonColor(label)} key={index}>
@@ -325,7 +332,7 @@ const NavBar = ({ headersData, user, setUser }: Props): ReactElement => {
         <Grid item md={9} container alignItems="center">
           <Grid item>{homeLogo}</Grid>
           <Grid item className={searchBar ? search : searchHidden}>
-            {auto()}
+            <Autocomplete drawerOpen={drawerOpen} setDrawerOpen={setDrawerOpen} />
           </Grid>
         </Grid>
 

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -38,6 +38,7 @@ const HomePage = (): ReactElement => {
   const classes = useStyles();
   const [data, setData] = useState<returnData>({ buildingData: [], isEnded: false });
   const [isMobile, setIsMobile] = useState<boolean>(false);
+  const [drawerOpen, setDrawerOpen] = useState<boolean>(false);
 
   useEffect(() => {
     get<returnData>(`/api/page-data/home/${loadingLength}`, {
@@ -80,7 +81,7 @@ const HomePage = (): ReactElement => {
           </Box>
 
           <Box pb={5} mx={0} mt={-4} paddingBottom={isMobile ? 4 : 8}>
-            <Autocomplete />
+            <Autocomplete drawerOpen={drawerOpen} setDrawerOpen={setDrawerOpen} />
           </Box>
         </Container>
       </Box>


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request implemented the new search bar design.

- [x] implemented search bar design
- [x] implemented different search bar placeholder texts depending on page according to Figma (only placeholder text on home page)

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
Normal zoom – no placeholder text as Figma design shows:
<img width="1436" alt="Screen Shot 2023-05-12 at 23 17 52" src="https://github.com/cornell-dti/cu-apts/assets/125820523/8295457e-0fd4-4322-9830-785be583b849">

Home page normal zoom (placeholder text is present):
<img width="1440" alt="Screen Shot 2023-05-12 at 23 18 44" src="https://github.com/cornell-dti/cu-apts/assets/125820523/9504f848-a91b-406b-b942-74ba722b1c7d">

Zoomed in maximum:
<img width="1440" alt="Screen Shot 2023-05-12 at 23 24 57" src="https://github.com/cornell-dti/cu-apts/assets/125820523/66128253-37b4-4a82-af5a-38bc55caeceb">

Zoomed out maximum:
<img width="1440" alt="Screen Shot 2023-05-12 at 23 19 26" src="https://github.com/cornell-dti/cu-apts/assets/125820523/057cb0a4-3c85-4efa-9350-6d45a5e82ceb">

Search bar in menu drawer:
<img width="883" alt="Screen Shot 2023-05-12 at 23 19 08" src="https://github.com/cornell-dti/cu-apts/assets/125820523/647c2ab3-f62a-4a84-a453-46c37c69bbbe">

Mobile display of home page:
<img width="373" alt="Screen Shot 2023-05-12 at 23 20 33" src="https://github.com/cornell-dti/cu-apts/assets/125820523/7cdfc514-1e66-4907-a847-726de337357e">