### PR TITLE
Implement Delete Button to Admin Page

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -300,7 +300,7 @@ app.post('/api/remove-like', authenticate, likeHandler(true));
 
 app.put('/api/update-review-status/:reviewDocId/:newStatus', async (req, res) => {
   const { reviewDocId, newStatus } = req.params;
-  const statusList = ['PENDING', 'APPROVED', 'DECLINED'];
+  const statusList = ['PENDING', 'APPROVED', 'DECLINED', 'DELETED'];
   try {
     if (!statusList.includes(newStatus)) {
       res.status(400).send('Invalid status type');

--- a/frontend/src/components/Admin/AdminReview.tsx
+++ b/frontend/src/components/Admin/AdminReview.tsx
@@ -28,6 +28,7 @@ import axios from 'axios';
 type Props = {
   readonly review: ReviewWithId;
   readonly setToggle: React.Dispatch<React.SetStateAction<boolean>>;
+  readonly declinedSection: boolean;
 };
 
 export type RatingInfo = {
@@ -61,7 +62,7 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-const AdminReviewComponent = ({ review, setToggle }: Props): ReactElement => {
+const AdminReviewComponent = ({ review, setToggle, declinedSection }: Props): ReactElement => {
   const { detailedRatings, overallRating, date, reviewText, photos } = review;
   const formattedDate = format(new Date(date), 'MMM dd, yyyy').toUpperCase();
   const { root, dateText, ratingInfo, photoStyle, photoRowStyle } = useStyles();
@@ -169,6 +170,17 @@ const AdminReviewComponent = ({ review, setToggle }: Props): ReactElement => {
 
       <CardActions>
         <Grid container spacing={2} alignItems="center" justifyContent="flex-end">
+          {declinedSection && (
+            <Grid item>
+              <Button
+                onClick={() => changeStatus('DELETED')}
+                variant="contained"
+                style={{ color: colors.black }}
+              >
+                <strong>Delete</strong>
+              </Button>
+            </Grid>
+          )}
           <Grid item>
             <Button
               onClick={() => changeStatus('DECLINED')}

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -49,7 +49,11 @@ const AdminPage = (): ReactElement => {
           <Grid container item spacing={3}>
             {sortReviews(pendingData, 'date').map((review, index) => (
               <Grid item xs={12} key={index}>
-                <AdminReviewComponent review={review} setToggle={setToggle} />
+                <AdminReviewComponent
+                  review={review}
+                  setToggle={setToggle}
+                  declinedSection={false}
+                />
               </Grid>
             ))}
           </Grid>
@@ -62,7 +66,11 @@ const AdminPage = (): ReactElement => {
           <Grid container item spacing={3}>
             {sortReviews(declinedData, 'date').map((review, index) => (
               <Grid item xs={12} key={index}>
-                <AdminReviewComponent review={review} setToggle={setToggle} />
+                <AdminReviewComponent
+                  review={review}
+                  setToggle={setToggle}
+                  declinedSection={true}
+                />
               </Grid>
             ))}
           </Grid>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4116,9 +4116,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001286:
-  version "1.0.30001431"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001431.tgz"
-  integrity sha512-zBUoFU0ZcxpvSt9IU66dXVT/3ctO1cy4y9cscs1szkPlcWb6pasYM144GqrUygUbT+k7cmUCW61cvskjcv0enQ==
+  version "1.0.30001525"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001525.tgz"
+  integrity sha512-/3z+wB4icFt3r0USMwxujAqRvaD/B7rvGTsKhbhSQErVrJvkZCLhgNLJxU8MevahQVH6hCU9FsHdNUFbiwmE7Q==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request implements the delete button to the admin page for the declined section so that admin users can stop seeing reviews that they want to delete. 

<img width="1339" alt="PNG image" src="https://github.com/cornell-dti/cu-apts/assets/32402949/4454307a-6ab7-4489-9389-9fb56b7e651c">
<img width="1342" alt="PNG image" src="https://github.com/cornell-dti/cu-apts/assets/32402949/37a1c9d6-38a9-4b3b-afbe-ebdf3f3f8251">


### Test Plan <!-- Required -->

Tested it locally.

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes  <!-- Optional -->
None
<!-- Keep items that apply: -->