### PR TITLE
Total review counts and review counts per location on admin page

### DIFF
--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -13,18 +13,43 @@ const useStyles = makeStyles((theme) => ({
 const AdminPage = (): ReactElement => {
   const [pendingData, setPendingData] = useState<ReviewWithId[]>([]);
   const [declinedData, setDeclinedData] = useState<ReviewWithId[]>([]);
+  const [approvedData, setApprovedData] = useState<ReviewWithId[]>([]);
+
+  type ReviewCount = { count: number };
+  const [ctownReviewCount, setCtownReviewCount] = useState<ReviewCount>({ count: 0 });
+  const [westReviewCount, setWestReviewCount] = useState<ReviewCount>({ count: 0 });
+  const [dtownReviewCount, setDtownReviewCount] = useState<ReviewCount>({ count: 0 });
+  const [northReviewCount, setNorthReviewCount] = useState<ReviewCount>({ count: 0 });
   const [toggle, setToggle] = useState(false);
+
   const { container } = useStyles();
 
+  // calls the APIs and the callback function to set the reviews for each review type
   useEffect(() => {
-    get<ReviewWithId[]>(`/api/review/PENDING`, {
-      callback: setPendingData,
+    const reviewTypes = new Map<string, React.Dispatch<React.SetStateAction<ReviewWithId[]>>>([
+      ['PENDING', setPendingData],
+      ['DECLINED', setDeclinedData],
+      ['APPROVED', setApprovedData],
+    ]);
+    reviewTypes.forEach((cllbck, reviewType) => {
+      get<ReviewWithId[]>(`/api/review/${reviewType}`, {
+        callback: cllbck,
+      });
     });
   }, [toggle]);
 
+  // sets counts for each location
   useEffect(() => {
-    get<ReviewWithId[]>(`/api/review/DECLINED`, {
-      callback: setDeclinedData,
+    const reviewCounts = new Map<string, React.Dispatch<React.SetStateAction<ReviewCount>>>([
+      ['COLLEGETOWN', setCtownReviewCount],
+      ['DOWNTOWN', setDtownReviewCount],
+      ['WEST', setWestReviewCount],
+      ['NORTH', setNorthReviewCount],
+    ]);
+    reviewCounts.forEach((cllbck, location) => {
+      get<ReviewCount>(`/api/review/${location}/count`, {
+        callback: cllbck,
+      });
     });
   }, [toggle]);
 
@@ -42,6 +67,18 @@ const AdminPage = (): ReactElement => {
   return (
     <Container className={container}>
       <Grid container spacing={5} justifyContent="center">
+        <Grid item xs={12} sm={12}>
+          <Typography variant="h3">
+            <strong>Review Counts</strong>
+          </Typography>
+          <ul>
+            <li>Total: {approvedData.length}</li>
+            <li>Collegetown: {ctownReviewCount.count}</li>
+            <li>West: {westReviewCount.count}</li>
+            <li>Downtown: {dtownReviewCount.count}</li>
+            <li>North: {northReviewCount.count}</li>
+          </ul>
+        </Grid>
         <Grid item xs={12} sm={12}>
           <Typography variant="h3">
             <strong>Pending Reviews</strong>


### PR DESCRIPTION
### Summary <!-- Required -->

This PR adds counts for the total number of approved reviews on the platform, and it shows the number of reviews approved for each location (North, West, Collegetown, and Downtown).

### Test Plan <!-- Required -->

<img width="331" alt="image" src="https://github.com/cornell-dti/cu-apts/assets/69130822/f845d0f6-c5d5-4499-bd35-ecee39f69548">

I manually verified the counts by counting them in the UI.

### Notes <!-- Optional -->

Let me know if it's too ugly and I can change it.