### PR TITLE
Add auto scrolling upward when clicking on another apartment 

### DIFF
--- a/frontend/src/components/Review/PropertyInfo.tsx
+++ b/frontend/src/components/Review/PropertyInfo.tsx
@@ -27,6 +27,7 @@ const useStyles = makeStyles({
   card: {
     borderRadius: '10px',
     backgroundColor: colors.red6,
+    cursor: 'pointer', // Add cursor pointer to make it clickable
   },
   reviewNum: {
     fontWeight: 700,
@@ -39,6 +40,18 @@ const PropertyCard = ({ buildingData, numReviews, company }: CardProps): ReactEl
   const { id, name, address } = buildingData;
   const [reviewData, setReviewData] = useState<ReviewWithId[]>([]);
 
+  /**
+   * Handles clicking on the Apartment card. Scrolls up on the window, upward
+   * to reach the top with a smooth behavior. The top is defined as 0 since this is
+   * where we want to reach.
+   */
+  const handleCardClick = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    });
+  };
+
   useEffect(() => {
     get<ReviewWithId[]>(`/api/review/aptId/${id}/APPROVED`, {
       callback: setReviewData,
@@ -46,7 +59,7 @@ const PropertyCard = ({ buildingData, numReviews, company }: CardProps): ReactEl
   }, [id]);
 
   return (
-    <Card className={card}>
+    <Card className={card} onClick={handleCardClick}>
       <CardContent>
         <Grid container direction="row" alignItems="center">
           <Grid item>


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request implements:

- [x] Add auto scrolling upward when clicking on another apartment 

### Test Plan <!-- Required -->

Tested on different devices and screen sizes by checking that it auto scrolls upward.

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes  <!-- Optional -->

<!-- Keep items that apply: -->
None