### PR TITLE
Add & Remove Saved Apartment/Landlord Endpoints

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -316,9 +316,9 @@ const likeHandler =
     }
   };
 
-app.post('/api/add-like', authenticate, likeHandler(false));
+app.post('/api/add-like', likeHandler(false));
 
-app.post('/api/remove-like', authenticate, likeHandler(true));
+app.post('/api/remove-like', likeHandler(true));
 
 /**
  * Handles saving or removing saved apartments for a user in the database.
@@ -426,13 +426,13 @@ const saveLandlordHandler =
     }
   };
 
-app.post('/api/add-saved-apartment', authenticate, saveApartmentHandler(true));
+app.post('/api/add-saved-apartment', saveApartmentHandler(true));
 
-app.post('/api/remove-saved-apartment', authenticate, saveApartmentHandler(false));
+app.post('/api/remove-saved-apartment', saveApartmentHandler(false));
 
-app.post('/api/add-saved-landlord', authenticate, saveLandlordHandler(true));
+app.post('/api/add-saved-landlord', saveLandlordHandler(true));
 
-app.post('/api/remove-saved-landlord', authenticate, saveLandlordHandler(false));
+app.post('/api/remove-saved-landlord', saveLandlordHandler(false));
 
 app.put('/api/update-review-status/:reviewDocId/:newStatus', async (req, res) => {
   const { reviewDocId, newStatus } = req.params;

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -319,6 +319,60 @@ app.post('/api/add-like', authenticate, likeHandler(false));
 
 app.post('/api/remove-like', authenticate, likeHandler(true));
 
+const saveApartmentHandler =
+  (dislike = false): RequestHandler =>
+  async (req, res) => {
+    try {
+      if (!req.user) throw new Error('not authenticated');
+      const { uid } = req.user;
+      const { reviewId } = req.body;
+      if (!reviewId) throw new Error('must specify review id');
+      const likesRef = likesCollection.doc(uid);
+      const reviewRef = reviewCollection.doc(reviewId);
+      await db.runTransaction(async (t) => {
+        const likesDoc = await t.get(likesRef);
+        const result = likesDoc.get(reviewId);
+        if (dislike ? result : !result) {
+          const likeEntry = dislike ? FieldValue.delete() : true;
+          const likeChange = dislike ? -1 : 1;
+          t.set(likesRef, { [reviewId]: likeEntry }, { merge: true });
+          t.update(reviewRef, { likes: FieldValue.increment(likeChange) });
+        }
+      });
+      res.status(200).send(JSON.stringify({ result: 'Success' }));
+    } catch (err) {
+      console.error(err);
+      res.status(400).send('Error');
+    }
+  };
+
+const saveLandlordHandler =
+  (dislike = false): RequestHandler =>
+  async (req, res) => {
+    try {
+      if (!req.user) throw new Error('not authenticated');
+      const { uid } = req.user;
+      const { reviewId } = req.body;
+      if (!reviewId) throw new Error('must specify review id');
+      const likesRef = likesCollection.doc(uid);
+      const reviewRef = reviewCollection.doc(reviewId);
+      await db.runTransaction(async (t) => {
+        const likesDoc = await t.get(likesRef);
+        const result = likesDoc.get(reviewId);
+        if (dislike ? result : !result) {
+          const likeEntry = dislike ? FieldValue.delete() : true;
+          const likeChange = dislike ? -1 : 1;
+          t.set(likesRef, { [reviewId]: likeEntry }, { merge: true });
+          t.update(reviewRef, { likes: FieldValue.increment(likeChange) });
+        }
+      });
+      res.status(200).send(JSON.stringify({ result: 'Success' }));
+    } catch (err) {
+      console.error(err);
+      res.status(400).send('Error');
+    }
+  };
+
 app.put('/api/update-review-status/:reviewDocId/:newStatus', async (req, res) => {
   const { reviewDocId, newStatus } = req.params;
   const statusList = ['PENDING', 'APPROVED', 'DECLINED', 'DELETED'];

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -328,44 +328,46 @@ app.post('/api/remove-like', authenticate, likeHandler(true));
 const saveApartmentHandler =
   (add = true): RequestHandler =>
   async (req, res) => {
+    console.log('T1');
     try {
+      console.log('T1');
       if (!req.user) throw new Error('Not authenticated');
       const { uid } = req.user;
       const { apartment } = req.body;
-
+      console.log(apartment);
       if (!apartment) throw new Error('Must specify apartment');
+      console.log('T3');
+      //   const userRef = usersCollection.doc(uid);
+      //   const apartmentRef = buildingsCollection.doc(apartment);
+      //   console.log("T4")
+      //   if (!userRef) {
+      //     throw new Error('User data not found');
+      //   }
 
-      const userRef = usersCollection.doc(uid);
-      const apartmentRef = buildingsCollection.doc(apartment);
+      //   await db.runTransaction(async (t) => {
+      //     const userDoc = await t.get(userRef);
+      //     const apartmentDoc = await t.get(apartmentRef);
 
-      if (!userRef) {
-        throw new Error('User data not found');
-      }
+      //     if (!userDoc || !userDoc.exists || !apartmentDoc.exists) {
+      //       throw new Error('User or apartment data not found');
+      //     }
+      //     const userApartments = userDoc.data()?.apartments || [];
 
-      await db.runTransaction(async (t) => {
-        const userDoc = await t.get(userRef);
-        const apartmentDoc = await t.get(apartmentRef);
+      //     if (add) {
+      //       if (!userApartments.includes(apartment)) {
+      //         userApartments.push(apartment);
+      //       }
+      //     } else {
+      //       const index = userApartments.indexOf(apartment);
+      //       if (index !== -1) {
+      //         userApartments.splice(index, 1);
+      //       }
+      //     }
 
-        if (!userDoc || !userDoc.exists || !apartmentDoc.exists) {
-          throw new Error('User or apartment data not found');
-        }
-        const userApartments = userDoc.data()?.apartments || [];
+      //     t.update(userRef, { apartments: userApartments });
+      //   });
 
-        if (add) {
-          if (!userApartments.includes(apartment)) {
-            userApartments.push(apartment);
-          }
-        } else {
-          const index = userApartments.indexOf(apartment);
-          if (index !== -1) {
-            userApartments.splice(index, 1);
-          }
-        }
-
-        t.update(userRef, { apartments: userApartments });
-      });
-
-      res.status(200).send(JSON.stringify({ result: 'Success' }));
+      //   res.status(200).send(JSON.stringify({ result: 'Success' }));
     } catch (err) {
       console.error(err);
       res.status(400).send('Error');

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -21,7 +21,6 @@ const reviewCollection = db.collection('reviews');
 const landlordCollection = db.collection('landlords');
 const buildingsCollection = db.collection('buildings');
 const likesCollection = db.collection('likes');
-const usersCollection = db.collection('users');
 
 const app: Express = express();
 
@@ -293,9 +292,9 @@ const likeHandler =
   (dislike = false): RequestHandler =>
   async (req, res) => {
     try {
-      // if (!req.user) throw new Error('not authenticated');
-      const { uid, reviewId } = req.body;
-      // const { reviewId } = req.body;
+      if (!req.user) throw new Error('not authenticated');
+      const { uid } = req.user;
+      const { reviewId } = req.body;
       if (!reviewId) throw new Error('must specify review id');
       const likesRef = likesCollection.doc(uid);
       const reviewRef = reviewCollection.doc(reviewId);
@@ -316,123 +315,9 @@ const likeHandler =
     }
   };
 
-app.post('/api/add-like', likeHandler(false));
+app.post('/api/add-like', authenticate, likeHandler(false));
 
-app.post('/api/remove-like', likeHandler(true));
-
-/**
- * Handles saving or removing saved apartments for a user in the database.
- *
- * @param add - If true, the apartment is added to the user's saved list. If false, it is removed.
- */
-const saveApartmentHandler =
-  (add = true): RequestHandler =>
-  async (req, res) => {
-    try {
-      if (!req.user) throw new Error('Not authenticated');
-      const { uid } = req.user;
-      const { apartment } = req.body;
-
-      if (!apartment) throw new Error('Must specify apartment');
-
-      const userRef = usersCollection.doc(uid);
-      const apartmentRef = buildingsCollection.doc(apartment);
-
-      if (!userRef) {
-        throw new Error('User data not found');
-      }
-
-      await db.runTransaction(async (t) => {
-        const userDoc = await t.get(userRef);
-        const apartmentDoc = await t.get(apartmentRef);
-
-        if (!userDoc || !userDoc.exists || !apartmentDoc.exists) {
-          throw new Error('User or apartment data not found');
-        }
-        const userApartments = userDoc.data()?.apartments || [];
-
-        if (add) {
-          if (!userApartments.includes(apartment)) {
-            userApartments.push(apartment);
-          }
-        } else {
-          const index = userApartments.indexOf(apartment);
-          if (index !== -1) {
-            userApartments.splice(index, 1);
-          }
-        }
-
-        t.update(userRef, { apartments: userApartments });
-      });
-
-      res.status(200).send(JSON.stringify({ result: 'Success' }));
-    } catch (err) {
-      console.error(err);
-      res.status(400).send('Error');
-    }
-  };
-
-/**
- * Handles saving or removing saved landlords for a user in the database.
- *
- * @param add - If true, the landlord is added to the user's saved list. If false, it is removed.
- */
-const saveLandlordHandler =
-  (add = true): RequestHandler =>
-  async (req, res) => {
-    try {
-      if (!req.user) throw new Error('Not authenticated');
-      const { uid } = req.user;
-      const { landlord } = req.body;
-
-      if (!landlord) throw new Error('Must specify landlord');
-
-      const userRef = usersCollection.doc(uid);
-      const landlordRef = landlordCollection.doc(landlord);
-
-      if (!userRef) {
-        throw new Error('User data not found');
-      }
-
-      await db.runTransaction(async (t) => {
-        const userDoc = await t.get(userRef);
-        const landlordDoc = await t.get(landlordRef);
-
-        if (!userDoc || !userDoc.exists || !landlordDoc.exists) {
-          throw new Error('User or landlord data not found');
-        }
-
-        // Check if userDoc.data() is not undefined before accessing landlord
-        const userLandlords = userDoc.data()?.landlords || [];
-
-        if (add) {
-          if (!userLandlords.includes(landlord)) {
-            userLandlords.push(landlord);
-          }
-        } else {
-          const index = userLandlords.indexOf(landlord);
-          if (index !== -1) {
-            userLandlords.splice(index, 1);
-          }
-        }
-
-        t.update(userRef, { landlords: userLandlords });
-      });
-
-      res.status(200).send(JSON.stringify({ result: 'Success' }));
-    } catch (err) {
-      console.error(err);
-      res.status(400).send('Error');
-    }
-  };
-
-app.post('/api/add-saved-apartment', saveApartmentHandler(true));
-
-app.post('/api/remove-saved-apartment', saveApartmentHandler(false));
-
-app.post('/api/add-saved-landlord', saveLandlordHandler(true));
-
-app.post('/api/remove-saved-landlord', saveLandlordHandler(false));
+app.post('/api/remove-like', authenticate, likeHandler(true));
 
 app.put('/api/update-review-status/:reviewDocId/:newStatus', async (req, res) => {
   const { reviewDocId, newStatus } = req.params;

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -293,9 +293,9 @@ const likeHandler =
   (dislike = false): RequestHandler =>
   async (req, res) => {
     try {
-      if (!req.user) throw new Error('not authenticated');
-      const { uid } = req.user;
-      const { reviewId } = req.body;
+      // if (!req.user) throw new Error('not authenticated');
+      const { uid, reviewId } = req.body;
+      // const { reviewId } = req.body;
       if (!reviewId) throw new Error('must specify review id');
       const likesRef = likesCollection.doc(uid);
       const reviewRef = reviewCollection.doc(reviewId);

--- a/frontend/src/pages/ApartmentPage.tsx
+++ b/frontend/src/pages/ApartmentPage.tsx
@@ -342,18 +342,6 @@ const ApartmentPage = ({ user, setUser }: Props): ReactElement => {
     setReviewOpen(true);
   };
 
-  const testButton = async () => {
-    let user = await getUser(true);
-    setUser(user);
-    if (!user) {
-      showSignInErrorToast();
-      return;
-    }
-    const token = await user.getIdToken(true);
-    console.log(aptId);
-    axios.post('/api/add-saved-apartment', { aptId }, createAuthHeaders(token));
-  };
-
   const Modals = landlordData && apt && (
     <>
       <ReviewModal
@@ -424,15 +412,6 @@ const ApartmentPage = ({ user, setUser }: Props): ReactElement => {
                 onClick={openReviewModal}
               >
                 Leave a Review
-              </Button>
-              <Button
-                color="primary"
-                className={reviewButton}
-                variant="contained"
-                disableElevation
-                onClick={testButton}
-              >
-                Test API
               </Button>
             </Grid>
             <Grid item>

--- a/frontend/src/pages/ApartmentPage.tsx
+++ b/frontend/src/pages/ApartmentPage.tsx
@@ -342,6 +342,18 @@ const ApartmentPage = ({ user, setUser }: Props): ReactElement => {
     setReviewOpen(true);
   };
 
+  const testButton = async () => {
+    let user = await getUser(true);
+    setUser(user);
+    if (!user) {
+      showSignInErrorToast();
+      return;
+    }
+    const token = await user.getIdToken(true);
+    console.log(aptId);
+    axios.post('/api/add-saved-apartment', { aptId }, createAuthHeaders(token));
+  };
+
   const Modals = landlordData && apt && (
     <>
       <ReviewModal
@@ -412,6 +424,15 @@ const ApartmentPage = ({ user, setUser }: Props): ReactElement => {
                 onClick={openReviewModal}
               >
                 Leave a Review
+              </Button>
+              <Button
+                color="primary"
+                className={reviewButton}
+                variant="contained"
+                disableElevation
+                onClick={testButton}
+              >
+                Test API
               </Button>
             </Grid>
             <Grid item>


### PR DESCRIPTION
### Summary <!-- Required -->

This adds the add and remove saved apartment and saved landlord endpoints into our backend to begin working on the front end. 


### Test Plan <!-- Required -->

The feature was tested by having a dummy button on the apartment page that called the API, and then manually checking the firebase. In this image, you can see that I was successfully able to add 10, an apartment ID, to my saved apartments in the user database. 

<img width="1056" alt="Screenshot 2023-11-12 at 6 06 15 PM" src="https://github.com/cornell-dti/cu-apts/assets/32402949/2a617858-dca8-415d-854b-68c072c2b750">

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes  <!-- Optional -->

None