### PR TITLE
Add endpoint for retrieve liked reviews of current user

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -97,6 +97,7 @@ app.get('/api/review/like', authenticate, async (req, res) => {
       const matchingReviews: ReviewWithId[] = [];
       const querySnapshot = await reviewCollection
         .where(FieldPath.documentId(), 'in', reviewIds)
+        .where('status', '==', 'APPROVED')
         .get();
       querySnapshot.forEach((doc) => {
         const reviewData = doc.data();

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -13,7 +13,7 @@ import {
   ApartmentWithLabel,
   ApartmentWithId,
 } from '@common/types/db-types';
-import { db, FieldValue } from './firebase-config';
+import { db, FieldValue, FieldPath } from './firebase-config';
 import { Faq } from './firebase-config/types';
 import authenticate from './auth';
 
@@ -80,6 +80,34 @@ app.get('/api/review/:status', async (req, res) => {
     return { ...review, id: doc.id } as ReviewWithId;
   });
   res.status(200).send(JSON.stringify(reviews));
+});
+
+/**
+ * Return list of reviews that user marked as helpful (like)
+ */
+app.get('/api/review/like', authenticate, async (req, res) => {
+  if (!req.user) throw new Error('not authenticated');
+  const { uid } = req.user;
+  const likesDoc = await likesCollection.doc(uid).get();
+
+  if (likesDoc.exists) {
+    const data = likesDoc.data();
+    if (data) {
+      const reviewIds = Object.keys(data);
+      const matchingReviews: ReviewWithId[] = [];
+      const querySnapshot = await reviewCollection
+        .where(FieldPath.documentId(), 'in', reviewIds)
+        .get();
+      querySnapshot.forEach((doc) => {
+        const reviewData = doc.data();
+        matchingReviews.push({ ...reviewData, id: doc.id } as ReviewWithId);
+      });
+      res.status(200).send(JSON.stringify(matchingReviews));
+      return;
+    }
+  }
+
+  res.status(200).send(JSON.stringify([]));
 });
 
 /**

--- a/backend/src/firebase-config/index.ts
+++ b/backend/src/firebase-config/index.ts
@@ -18,6 +18,6 @@ admin.initializeApp({
 const db = admin.firestore();
 const auth = admin.auth();
 
-const { FieldValue } = admin.firestore;
+const { FieldValue, FieldPath } = admin.firestore;
 
-export { db, auth, FieldValue };
+export { db, auth, FieldValue, FieldPath };


### PR DESCRIPTION
Add endpoint GET `/api/review/like` that returns a list of `ReviewWithId[]` that the current user marked as helpful (like). This endpoint can only be called when the user has signed in. 

Testing: Postman with unauthenticated version `/api/review/like/:userId` as below:
- GET: http://localhost:8080/api/review/like/P6abmpm0yaclfZ2RWfokdbTuADD3
- Result (in the picture):  
<img width="1301" alt="Screenshot 2023-11-09 at 5 31 38 PM" src="https://github.com/cornell-dti/cu-apts/assets/62644357/874da919-ee15-4490-b334-e76003998394">
