### PR TITLE
Added add_price_and_bedroom_attributes.ts file

### DIFF
--- a/backend/scripts/add_price_and_bedroom_attributes.ts
+++ b/backend/scripts/add_price_and_bedroom_attributes.ts
@@ -1,0 +1,19 @@
+import { Review } from '@common/types/db-types';
+import { db } from '../src/firebase-config';
+
+// This script will add the price and bedrooms attributes to all the reviews that do not have them
+
+const reviewCollection = db.collection('reviews');
+
+reviewCollection.get().then((querySnapshot) => {
+  querySnapshot.forEach((doc) => {
+    console.log('Review Before Changes: ', doc.data());
+    // Version 1: Using Update?
+    reviewCollection.doc(doc.id).update({
+      price: 0,
+      bedrooms: 0,
+    });
+    console.log('Updated review with id: ', doc.id, ' with price and bedrooms attributes');
+    console.log('Review After Changes: ', doc.data());
+  });
+});


### PR DESCRIPTION
This script adds the price and bedrooms attributes to all the reviews that do not have them: setting them to zero as a default.

Tested by running on dev instance of FireStore.