### PR TITLE
Landlord text to button

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -1,2 +1,0 @@
-export NVM_DIR=~/.nvm
-source $(brew --prefix nvm)/nvm.sh

--- a/.zshrc
+++ b/.zshrc
@@ -1,0 +1,2 @@
+export NVM_DIR=~/.nvm
+source $(brew --prefix nvm)/nvm.sh

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ on its own, run `yarn frontend-dev` or `yarn backend-dev`.
 - **Jessica Han** - Developer
 - **Grace Sawatyanon** - Developer
 - **Miranda Luo** - Developer
-- **Casper Liao** - Developer
+- **Kea-Roy Ong** - Developer
 
 ### 2022-2023
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ on its own, run `yarn frontend-dev` or `yarn backend-dev`.
 - **Jessica Han** - Developer
 - **Grace Sawatyanon** - Developer
 - **Miranda Luo** - Developer
+- **Casper Liao** - Developer
 
 ### 2022-2023
 

--- a/frontend/src/components/Review/Review.tsx
+++ b/frontend/src/components/Review/Review.tsx
@@ -189,22 +189,25 @@ const ReviewComponent = ({
     return (
       showLabel && (
         <>
-          <Grid style={{ fontWeight: 'bold', marginRight: '5px' }}>
-            {apt.length > 0 ? 'Property: ' : 'Landlord: '}
-          </Grid>
           <Link
             {...{
               to: apt.length > 0 ? `/apartment/${review.aptId}` : `/landlord/${review.landlordId}`,
               style: {
-                color: 'black',
-                textDecoration: 'underline',
-                paddingBottom: '3px',
+                textDecoration: 'none',
+                display: 'inline-block',
+                width: '100%',
+                paddingLeft: '3px',
               },
               component: RouterLink,
             }}
             onClick={handleLinkClick}
           >
-            {apt.length > 0 ? apt[0].name : landlordData ? landlordData.name : ''}
+            <Button>
+              <Grid style={{ fontWeight: 'bold', marginRight: '5px' }}>
+                {apt.length > 0 ? 'Property: ' : 'Landlord: '}
+              </Grid>
+              {apt.length > 0 ? apt[0].name : landlordData ? landlordData.name : ''}
+            </Button>
           </Link>
         </>
       )


### PR DESCRIPTION
Change Property Underlined Text to Button for Reviews

- [x] Change the underlined text style to button style for the property on review cards

<img width="866" alt="Screenshot 2024-02-21 at 18 12 49" src="https://github.com/cornell-dti/cu-apts/assets/160357661/85dce526-65c4-442b-a730-cc5102edaa16">
*The [Property: ] text is not underlined now 

<img width="845" alt="Screenshot 2024-02-21 at 18 12 53" src="https://github.com/cornell-dti/cu-apts/assets/160357661/05ed1bd0-8267-404b-8ae3-303c1ab85c9e">
*The text/button area becomes darker when the mouse hovers over it. It has a similar style to the [Visit Landlord] button on ApartmentCard.