### PR TITLE
Add review photo carousel functionality

### DIFF
--- a/frontend/src/components/Admin/AdminReview.tsx
+++ b/frontend/src/components/Admin/AdminReview.tsx
@@ -228,6 +228,7 @@ const AdminReviewComponent = ({
                           title="Apt image"
                           className={photoStyle}
                           onClick={() => triggerPhotoCarousel(photos, i)}
+                          loading="lazy"
                         />
                       );
                     })}

--- a/frontend/src/components/Admin/AdminReview.tsx
+++ b/frontend/src/components/Admin/AdminReview.tsx
@@ -37,6 +37,8 @@ type Props = {
   readonly setToggle: React.Dispatch<React.SetStateAction<boolean>>;
   /** Indicates if the review is in the declined section. */
   readonly declinedSection: boolean;
+  /** Function to trigger the photo carousel. */
+  readonly triggerPhotoCarousel: (photos: readonly string[], startIndex: number) => void;
 };
 
 /**
@@ -70,14 +72,24 @@ const useStyles = makeStyles(() => ({
     borderRadius: '4px',
     height: '15em',
     width: '15em',
+    cursor: 'pointer',
+    transition: '0.3s ease-in-out',
+    '&:hover': {
+      filter: 'brightness(0.85)',
+      boxShadow: '0 4px 8px rgba(0, 0, 0, 0.5)',
+      transform: 'scale(1.02)',
+    },
   },
   photoRowStyle: {
     overflowX: 'auto',
+    overflowY: 'hidden',
     display: 'flex',
     flexDirection: 'row',
     gap: '1vw',
     paddingTop: '2%',
     paddingLeft: '0.6%',
+    paddingRight: '0.6%',
+    paddingBottom: '2%',
   },
 }));
 
@@ -87,7 +99,12 @@ const useStyles = makeStyles(() => ({
  * @param review review - The review to approve
  * @returns The rendered component.
  */
-const AdminReviewComponent = ({ review, setToggle, declinedSection }: Props): ReactElement => {
+const AdminReviewComponent = ({
+  review,
+  setToggle,
+  declinedSection,
+  triggerPhotoCarousel,
+}: Props): ReactElement => {
   const { detailedRatings, overallRating, bedrooms, price, date, reviewText, photos } = review;
   const formattedDate = format(new Date(date), 'MMM dd, yyyy').toUpperCase();
   const { root, dateText, bedroomsPriceText, ratingInfo, photoStyle, photoRowStyle } = useStyles();
@@ -202,7 +219,7 @@ const AdminReviewComponent = ({ review, setToggle, declinedSection }: Props): Re
               {photos.length > 0 && (
                 <Grid container>
                   <Grid item className={photoRowStyle}>
-                    {photos.map((photo) => {
+                    {photos.map((photo, i) => {
                       return (
                         <CardMedia
                           component="img"
@@ -210,6 +227,7 @@ const AdminReviewComponent = ({ review, setToggle, declinedSection }: Props): Re
                           image={photo}
                           title="Apt image"
                           className={photoStyle}
+                          onClick={() => triggerPhotoCarousel(photos, i)}
                         />
                       );
                     })}

--- a/frontend/src/components/Admin/AdminReview.tsx
+++ b/frontend/src/components/Admin/AdminReview.tsx
@@ -76,7 +76,7 @@ const useStyles = makeStyles(() => ({
     transition: '0.3s ease-in-out',
     '&:hover': {
       filter: 'brightness(0.85)',
-      boxShadow: '0 4px 8px rgba(0, 0, 0, 0.5)',
+      boxShadow: '0 4px 4px rgba(0, 0, 0, 0.1)',
       transform: 'scale(1.02)',
     },
   },

--- a/frontend/src/components/PhotoCarousel/PhotoCarousel.tsx
+++ b/frontend/src/components/PhotoCarousel/PhotoCarousel.tsx
@@ -19,14 +19,35 @@ const useStyles = makeStyles((theme) => ({
     backgroundColor: 'rgba(0, 0, 0, 0.5)',
     opacity: 1,
   },
+  indicatorContainer: {
+    position: 'absolute',
+    bottom: '-10px',
+    width: '100%',
+    textAlign: 'center',
+  },
+  carouselContainer: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexDirection: 'column',
+    overflow: 'visible',
+    height: '90dvh',
+    [theme.breakpoints.down('lg')]: {
+      height: '60dvw',
+    },
+  },
 }));
 const ImageBox = styled(Box)({
-  width: 'fit-content',
-  margin: 'auto',
   borderRadius: '10px',
-  overflow: 'hidden',
   maxHeight: '80dvh',
-  objectFit: 'contain',
+  backgroundColor: 'transparent',
+  '& img': {
+    borderRadius: '10px',
+    maxHeight: '80dvh',
+    objectFit: 'contain',
+    width: 'calc(69dvw - 96px)',
+    margin: 'auto',
+  },
 });
 
 /**
@@ -45,20 +66,22 @@ const ImageBox = styled(Box)({
  * @returns {JSX.Element} The rendered PhotoCarousel component.
  */
 const PhotoCarousel = ({ photos, open, onClose, startIndex }: Props) => {
-  const { modalBackground, navButton } = useStyles();
+  const { modalBackground, navButton, indicatorContainer, carouselContainer } = useStyles();
   return (
     <Dialog
       open={open}
       onClose={onClose}
       fullWidth
-      maxWidth="md"
+      maxWidth={false}
       PaperProps={{ className: modalBackground }}
     >
       <Container>
         <Carousel
           autoPlay={false}
+          className={carouselContainer}
           navButtonsAlwaysVisible={true}
           navButtonsProps={{ className: navButton }}
+          indicatorContainerProps={{ className: indicatorContainer }}
           index={startIndex}
         >
           {photos.map((src, index) => {

--- a/frontend/src/components/PhotoCarousel/PhotoCarousel.tsx
+++ b/frontend/src/components/PhotoCarousel/PhotoCarousel.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import { Modal, Box, styled, Container, CardMedia, Dialog, makeStyles } from '@material-ui/core';
+import { Box, styled, Container, CardMedia, Dialog, makeStyles } from '@material-ui/core';
 import Carousel from 'react-material-ui-carousel';
 
 interface Props {
   photos: readonly string[];
   open: boolean;
   onClose?: () => void;
+  startIndex: number;
 }
 
 const useStyles = makeStyles((theme) => ({
@@ -24,9 +25,26 @@ const ImageBox = styled(Box)({
   margin: 'auto',
   borderRadius: '10px',
   overflow: 'hidden',
+  maxHeight: '80dvh',
+  objectFit: 'contain',
 });
 
-const PhotoCarousel = ({ photos, open, onClose }: Props) => {
+/**
+ * PhotoCarousel - this component displays a modal with a carousel of photos.
+ *
+ * @remarks
+ * This component is used to display a modal with a carousel of photos.
+ * It dynamically adjusts to different screen sizes and can be navigated using the arrow buttons.
+ *
+ * @component
+ * @param {readonly string[]} props.photos - An array of photo URLs to display in the carousel.
+ * @param {boolean} props.open - A boolean indicating whether the modal is open.
+ * @param {() => void} [props.onClose] - An optional callback function to handle closing the modal.
+ * @param {number} props.startIndex - The starting index of the carousel.
+ *
+ * @returns {JSX.Element} The rendered PhotoCarousel component.
+ */
+const PhotoCarousel = ({ photos, open, onClose, startIndex }: Props) => {
   const { modalBackground, navButton } = useStyles();
   return (
     <Dialog
@@ -41,6 +59,7 @@ const PhotoCarousel = ({ photos, open, onClose }: Props) => {
           autoPlay={false}
           navButtonsAlwaysVisible={true}
           navButtonsProps={{ className: navButton }}
+          index={startIndex}
         >
           {photos.map((src, index) => {
             return (

--- a/frontend/src/components/PhotoCarousel/PhotoCarousel.tsx
+++ b/frontend/src/components/PhotoCarousel/PhotoCarousel.tsx
@@ -31,10 +31,11 @@ const useStyles = makeStyles((theme) => ({
     justifyContent: 'center',
     flexDirection: 'column',
     overflow: 'visible',
-    height: '90dvh',
-    [theme.breakpoints.down('lg')]: {
+    height: '80vh',
+    [theme.breakpoints.down('md')]: {
       height: '60dvw',
     },
+    cursor: 'pointer',
   },
 }));
 const ImageBox = styled(Box)({
@@ -47,6 +48,7 @@ const ImageBox = styled(Box)({
     objectFit: 'contain',
     width: 'calc(69dvw - 96px)',
     margin: 'auto',
+    cursor: 'default',
   },
 });
 
@@ -73,9 +75,23 @@ const PhotoCarousel = ({ photos, open, onClose, startIndex }: Props) => {
       onClose={onClose}
       fullWidth
       maxWidth={false}
+      style={{ cursor: 'pointer' }}
       PaperProps={{ className: modalBackground }}
     >
-      <Container>
+      <Container
+        onClick={(e) => {
+          const target = e.target as HTMLElement;
+          if (
+            target.tagName !== 'IMG' &&
+            target.tagName !== 'BUTTON' &&
+            target.tagName !== 'svg' &&
+            target.tagName !== 'circle'
+          ) {
+            console.log(target.tagName);
+            onClose?.();
+          }
+        }}
+      >
         <Carousel
           autoPlay={false}
           className={carouselContainer}
@@ -83,10 +99,11 @@ const PhotoCarousel = ({ photos, open, onClose, startIndex }: Props) => {
           navButtonsProps={{ className: navButton }}
           indicatorContainerProps={{ className: indicatorContainer }}
           index={startIndex}
+          animation="fade"
         >
           {photos.map((src, index) => {
             return (
-              <ImageBox key={index}>
+              <ImageBox key={index} style={{ backgroundColor: 'rgba(0, 0, 0, 0.05)' }}>
                 <CardMedia component="img" src={src} />
               </ImageBox>
             );

--- a/frontend/src/components/PhotoCarousel/usePhotoCarousel.ts
+++ b/frontend/src/components/PhotoCarousel/usePhotoCarousel.ts
@@ -1,0 +1,39 @@
+// src/hooks/usePhotoCarousel.ts
+import { useState } from 'react';
+
+const usePhotoCarousel = (defaultPhotos: readonly string[] = []) => {
+  const [carouselPhotos, setCarouselPhotos] = useState<readonly string[]>(defaultPhotos);
+  const [carouselStartIndex, setCarouselStartIndex] = useState<number>(0);
+  const [carouselOpen, setCarouselOpen] = useState<boolean>(false);
+
+  /**
+   * showPhotoCarousel – Opens the photo carousel modal with the provided photos and start index.
+   *
+   * @remarks
+   * This function sets the photos and start index for the photo carousel and then opens the carousel modal.
+   * If no photos are provided, it defaults to [defaultPhotos].
+   *
+   * @param {readonly string[]} [photos] – The array of photo URLs to display in the carousel.
+   * @param {number} [startIndex] – The index of the photo to start the carousel from.
+   * @return {void} – This function does not return anything.
+   */
+  const showPhotoCarousel = (photos: readonly string[] = defaultPhotos, startIndex: number = 0) => {
+    setCarouselPhotos(photos);
+    setCarouselStartIndex(startIndex);
+    setCarouselOpen(true);
+  };
+
+  const closePhotoCarousel = () => {
+    setCarouselOpen(false);
+  };
+
+  return {
+    carouselPhotos,
+    carouselStartIndex,
+    carouselOpen,
+    showPhotoCarousel,
+    closePhotoCarousel,
+  };
+};
+
+export default usePhotoCarousel;

--- a/frontend/src/components/Review/Review.tsx
+++ b/frontend/src/components/Review/Review.tsx
@@ -96,7 +96,7 @@ const useStyles = makeStyles(() => ({
     transition: '0.3s ease-in-out',
     '&:hover': {
       filter: 'brightness(0.85)',
-      boxShadow: '0 4px 8px rgba(0, 0, 0, 0.5)',
+      boxShadow: '0 4px 4px rgba(0, 0, 0, 0.1)',
       transform: 'scale(1.02)',
     },
   },

--- a/frontend/src/components/Review/Review.tsx
+++ b/frontend/src/components/Review/Review.tsx
@@ -44,7 +44,8 @@ type Props = {
   readonly addLike: (reviewId: string) => Promise<void>;
   readonly removeLike: (reviewId: string) => Promise<void>;
   setToggle: React.Dispatch<React.SetStateAction<boolean>>;
-  readonly triggerEditToast?: () => void;
+  readonly triggerEditToast: () => void;
+  readonly triggerPhotoCarousel: (photos: readonly string[], startIndex: number) => void;
   user: firebase.User | null;
   setUser: React.Dispatch<React.SetStateAction<firebase.User | null>>;
   readonly showLabel: boolean;
@@ -91,14 +92,24 @@ const useStyles = makeStyles(() => ({
     borderRadius: '4px',
     height: '15em',
     width: '15em',
+    cursor: 'pointer',
+    transition: '0.3s ease-in-out',
+    '&:hover': {
+      filter: 'brightness(0.85)',
+      boxShadow: '0 4px 8px rgba(0, 0, 0, 0.5)',
+      transform: 'scale(1.02)',
+    },
   },
   photoRowStyle: {
     overflowX: 'auto',
     display: 'flex',
-    lexDirection: 'row',
+    flexDirection: 'row',
     gap: '1vw',
     paddingTop: '2%',
     paddingLeft: '0.6%',
+    overflowY: 'hidden',
+    paddingRight: '0.6%',
+    paddingBottom: '2%',
   },
   bedroomsPrice: {
     display: 'flex',
@@ -122,6 +133,7 @@ const ReviewComponent = ({
   removeLike,
   setToggle,
   triggerEditToast,
+  triggerPhotoCarousel,
   user,
   setUser,
   showLabel,
@@ -374,7 +386,7 @@ const ReviewComponent = ({
               {reviewData.photos.length > 0 && (
                 <Grid container>
                   <Grid item className={photoRowStyle}>
-                    {reviewData.photos.map((photo) => {
+                    {reviewData.photos.map((photo, i) => {
                       return (
                         <CardMedia
                           component="img"
@@ -382,6 +394,7 @@ const ReviewComponent = ({
                           image={photo}
                           title="Apt image"
                           className={photoStyle}
+                          onClick={() => triggerPhotoCarousel(reviewData.photos, i)}
                         />
                       );
                     })}

--- a/frontend/src/components/Review/Review.tsx
+++ b/frontend/src/components/Review/Review.tsx
@@ -395,6 +395,7 @@ const ReviewComponent = ({
                           title="Apt image"
                           className={photoStyle}
                           onClick={() => triggerPhotoCarousel(reviewData.photos, i)}
+                          loading="lazy"
                         />
                       );
                     })}

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -19,6 +19,7 @@ import { useTitle } from '../utils';
 import { Chart } from 'react-google-charts';
 import { sortReviews } from '../utils/sortReviews';
 import PhotoCarousel from '../components/PhotoCarousel/PhotoCarousel';
+import usePhotoCarousel from '../components/PhotoCarousel/usePhotoCarousel';
 
 const useStyles = makeStyles((theme) => ({
   container: {
@@ -52,9 +53,13 @@ const AdminPage = (): ReactElement => {
   const [pendingApartment, setPendingApartmentData] = useState<CantFindApartmentForm[]>([]);
   const [pendingContactQuestions, setPendingContactQuestions] = useState<QuestionForm[]>([]);
 
-  const [carouselOpen, setCarouselOpen] = useState(false);
-  const [carouselPhotos, setCarouselPhotos] = useState<readonly string[]>([]);
-  const [carouselStartIndex, setCarouselStartIndex] = useState<number>(0);
+  const {
+    carouselPhotos,
+    carouselStartIndex,
+    carouselOpen,
+    showPhotoCarousel,
+    closePhotoCarousel,
+  } = usePhotoCarousel([]);
 
   const { container } = useStyles();
 
@@ -120,29 +125,12 @@ const AdminPage = (): ReactElement => {
     });
   }, [toggle]);
 
-  /**
-   * showPhotoCarousel – Opens the photo carousel modal with the provided photos and start index.
-   *
-   * @remarks
-   * This function sets the photos and start index for the photo carousel and then opens the carousel modal.
-   * If no photos are provided, it defaults to no photos.
-   *
-   * @param {readonly string[]} [photos] – The array of photo URLs to display in the carousel.
-   * @param {number} [startIndex] – The index of the photo to start the carousel from.
-   * @return {void} – This function does not return anything.
-   */
-  const showPhotoCarousel = (photos: readonly string[] = [], startIndex: number = 0) => {
-    setCarouselPhotos(photos);
-    setCarouselStartIndex(startIndex);
-    setCarouselOpen(true);
-  };
-
   const Modals = (
     <>
       <PhotoCarousel
         photos={carouselPhotos}
         open={carouselOpen}
-        onClose={() => setCarouselOpen(false)}
+        onClose={closePhotoCarousel}
         startIndex={carouselStartIndex}
       />
     </>

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -18,6 +18,7 @@ import AdminReviewComponent from '../components/Admin/AdminReview';
 import { useTitle } from '../utils';
 import { Chart } from 'react-google-charts';
 import { sortReviews } from '../utils/sortReviews';
+import PhotoCarousel from '../components/PhotoCarousel/PhotoCarousel';
 
 const useStyles = makeStyles((theme) => ({
   container: {
@@ -50,6 +51,10 @@ const AdminPage = (): ReactElement => {
 
   const [pendingApartment, setPendingApartmentData] = useState<CantFindApartmentForm[]>([]);
   const [pendingContactQuestions, setPendingContactQuestions] = useState<QuestionForm[]>([]);
+
+  const [carouselOpen, setCarouselOpen] = useState(false);
+  const [carouselPhotos, setCarouselPhotos] = useState<readonly string[]>([]);
+  const [carouselStartIndex, setCarouselStartIndex] = useState<number>(0);
 
   const { container } = useStyles();
 
@@ -115,6 +120,34 @@ const AdminPage = (): ReactElement => {
     });
   }, [toggle]);
 
+  /**
+   * showPhotoCarousel – Opens the photo carousel modal with the provided photos and start index.
+   *
+   * @remarks
+   * This function sets the photos and start index for the photo carousel and then opens the carousel modal.
+   * If no photos are provided, it defaults to no photos.
+   *
+   * @param {readonly string[]} [photos] – The array of photo URLs to display in the carousel.
+   * @param {number} [startIndex] – The index of the photo to start the carousel from.
+   * @return {void} – This function does not return anything.
+   */
+  const showPhotoCarousel = (photos: readonly string[] = [], startIndex: number = 0) => {
+    setCarouselPhotos(photos);
+    setCarouselStartIndex(startIndex);
+    setCarouselOpen(true);
+  };
+
+  const Modals = (
+    <>
+      <PhotoCarousel
+        photos={carouselPhotos}
+        open={carouselOpen}
+        onClose={() => setCarouselOpen(false)}
+        startIndex={carouselStartIndex}
+      />
+    </>
+  );
+
   //  Reviews tab
   const reviews = (
     <Container className={container}>
@@ -157,6 +190,7 @@ const AdminPage = (): ReactElement => {
                   review={review}
                   setToggle={setToggle}
                   declinedSection={false}
+                  triggerPhotoCarousel={showPhotoCarousel}
                 />
               </Grid>
             ))}
@@ -175,6 +209,7 @@ const AdminPage = (): ReactElement => {
                     review={review}
                     setToggle={setToggle}
                     declinedSection={true}
+                    triggerPhotoCarousel={showPhotoCarousel}
                   />
                 </Grid>
               ))}
@@ -246,6 +281,7 @@ const AdminPage = (): ReactElement => {
 
       {selectedTab === 'Reviews' && reviews}
       {selectedTab === 'Contact' && contact}
+      {Modals}
     </div>
   );
 };

--- a/frontend/src/pages/ApartmentPage.tsx
+++ b/frontend/src/pages/ApartmentPage.tsx
@@ -13,6 +13,7 @@ import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 
 import ReviewModal from '../components/LeaveReview/ReviewModal';
 import PhotoCarousel from '../components/PhotoCarousel/PhotoCarousel';
+import usePhotoCarousel from '../components/PhotoCarousel/usePhotoCarousel';
 import ReviewComponent from '../components/Review/Review';
 import ReviewHeader from '../components/Review/ReviewHeader';
 import { useTitle } from '../utils';
@@ -130,14 +131,18 @@ const ApartmentPage = ({ user, setUser }: Props): ReactElement => {
   const [likeStatuses, setLikeStatuses] = useState<Likes>({});
   const [reviewOpen, setReviewOpen] = useState(false);
   const [mapOpen, setMapOpen] = useState(false);
-  const [carouselOpen, setCarouselOpen] = useState(false);
-  const [carouselPhotos, setCarouselPhotos] = useState<readonly string[]>([]);
-  const [carouselStartIndex, setCarouselStartIndex] = useState<number>(0);
   const [showConfirmation, setShowConfirmation] = useState(false);
   const [showEditSuccessConfirmation, setShowEditSuccessConfirmation] = useState(false);
   const [buildings, setBuildings] = useState<Apartment[]>([]);
   const [aptData, setAptData] = useState<ApartmentWithId[]>([]);
   const [apt, setApt] = useState<ApartmentWithId | undefined>(undefined);
+  const {
+    carouselPhotos,
+    carouselStartIndex,
+    carouselOpen,
+    showPhotoCarousel,
+    closePhotoCarousel,
+  } = usePhotoCarousel(apt ? apt.photos : []);
   const [loaded, setLoaded] = useState(false);
   const [showSignInError, setShowSignInError] = useState(false);
   const [sortBy, setSortBy] = useState<Fields>('date');
@@ -374,26 +379,6 @@ const ApartmentPage = ({ user, setUser }: Props): ReactElement => {
     setReviewOpen(true);
   };
 
-  /**
-   * showPhotoCarousel – Opens the photo carousel modal with the provided photos and start index.
-   *
-   * @remarks
-   * This function sets the photos and start index for the photo carousel and then opens the carousel modal.
-   * If no photos are provided, it defaults to the apartment's photos.
-   *
-   * @param {readonly string[]} [photos] – The array of photo URLs to display in the carousel.
-   * @param {number} [startIndex] – The index of the photo to start the carousel from.
-   * @return {void} – This function does not return anything.
-   */
-  const showPhotoCarousel = (
-    photos: readonly string[] = apt ? apt.photos : [],
-    startIndex: number = 0
-  ) => {
-    setCarouselPhotos(photos);
-    setCarouselStartIndex(startIndex);
-    setCarouselOpen(true);
-  };
-
   const Modals = landlordData && apt && (
     <>
       <MapModal
@@ -422,7 +407,7 @@ const ApartmentPage = ({ user, setUser }: Props): ReactElement => {
         photos={carouselPhotos}
         open={carouselOpen}
         startIndex={carouselStartIndex}
-        onClose={() => setCarouselOpen(false)}
+        onClose={closePhotoCarousel}
       />
     </>
   );

--- a/frontend/src/pages/ApartmentPage.tsx
+++ b/frontend/src/pages/ApartmentPage.tsx
@@ -131,6 +131,8 @@ const ApartmentPage = ({ user, setUser }: Props): ReactElement => {
   const [reviewOpen, setReviewOpen] = useState(false);
   const [mapOpen, setMapOpen] = useState(false);
   const [carouselOpen, setCarouselOpen] = useState(false);
+  const [carouselPhotos, setCarouselPhotos] = useState<readonly string[]>([]);
+  const [carouselStartIndex, setCarouselStartIndex] = useState<number>(0);
   const [showConfirmation, setShowConfirmation] = useState(false);
   const [showEditSuccessConfirmation, setShowEditSuccessConfirmation] = useState(false);
   const [buildings, setBuildings] = useState<Apartment[]>([]);
@@ -372,6 +374,26 @@ const ApartmentPage = ({ user, setUser }: Props): ReactElement => {
     setReviewOpen(true);
   };
 
+  /**
+   * showPhotoCarousel – Opens the photo carousel modal with the provided photos and start index.
+   *
+   * @remarks
+   * This function sets the photos and start index for the photo carousel and then opens the carousel modal.
+   * If no photos are provided, it defaults to the apartment's photos.
+   *
+   * @param {readonly string[]} [photos] – The array of photo URLs to display in the carousel.
+   * @param {number} [startIndex] – The index of the photo to start the carousel from.
+   * @return {void} – This function does not return anything.
+   */
+  const showPhotoCarousel = (
+    photos: readonly string[] = apt ? apt.photos : [],
+    startIndex: number = 0
+  ) => {
+    setCarouselPhotos(photos);
+    setCarouselStartIndex(startIndex);
+    setCarouselOpen(true);
+  };
+
   const Modals = landlordData && apt && (
     <>
       <MapModal
@@ -397,8 +419,9 @@ const ApartmentPage = ({ user, setUser }: Props): ReactElement => {
         user={user}
       />
       <PhotoCarousel
-        photos={apt.photos}
+        photos={carouselPhotos}
         open={carouselOpen}
+        startIndex={carouselStartIndex}
         onClose={() => setCarouselOpen(false)}
       />
     </>
@@ -464,7 +487,7 @@ const ApartmentPage = ({ user, setUser }: Props): ReactElement => {
             color="secondary"
             variant="contained"
             disableElevation
-            onClick={() => setCarouselOpen(true)}
+            onClick={() => showPhotoCarousel()}
           >
             Show all photos
           </Button>
@@ -538,7 +561,7 @@ const ApartmentPage = ({ user, setUser }: Props): ReactElement => {
               color="secondary"
               variant="contained"
               disableElevation
-              onClick={() => setCarouselOpen(true)}
+              onClick={() => showPhotoCarousel()}
             >
               Show all photos
             </Button>
@@ -632,7 +655,7 @@ const ApartmentPage = ({ user, setUser }: Props): ReactElement => {
             averageRating={getAverageRating(reviewData)}
             apartment={apt!}
             numReviews={reviewData.length}
-            handleClick={() => setCarouselOpen(true)}
+            handleClick={() => showPhotoCarousel()}
           />
         </Container>
       )}
@@ -715,6 +738,7 @@ const ApartmentPage = ({ user, setUser }: Props): ReactElement => {
                             removeLike={removeLike}
                             setToggle={setToggle}
                             triggerEditToast={showEditSuccessConfirmationToast}
+                            triggerPhotoCarousel={showPhotoCarousel}
                             user={user}
                             setUser={setUser}
                           />

--- a/frontend/src/pages/BookmarksPage.tsx
+++ b/frontend/src/pages/BookmarksPage.tsx
@@ -16,6 +16,7 @@ import { sortReviews } from '../utils/sortReviews';
 import DropDownWithLabel from '../components/utils/DropDownWithLabel';
 import { AptSortFields, sortApartments } from '../utils/sortApartments';
 import Toast from '../components/utils/Toast';
+import PhotoCarousel from '../components/PhotoCarousel/PhotoCarousel';
 
 type Props = {
   user: firebase.User | null;
@@ -108,6 +109,9 @@ const BookmarksPage = ({ user, setUser }: Props): ReactElement => {
   const [showMoreLessState, setShowMoreLessState] = useState<string>('Show More');
   const [isMobile, setIsMobile] = useState<boolean>(false);
   const [showEditSuccessConfirmation, setShowEditSuccessConfirmation] = useState(false);
+  const [carouselOpen, setCarouselOpen] = useState(false);
+  const [carouselPhotos, setCarouselPhotos] = useState<readonly string[]>([]);
+  const [carouselStartIndex, setCarouselStartIndex] = useState<number>(0);
 
   useEffect(() => {
     const handleResize = () => setIsMobile(window.innerWidth <= 600);
@@ -202,6 +206,34 @@ const BookmarksPage = ({ user, setUser }: Props): ReactElement => {
   // Define two functions for handling likes and dislikes
   const addLike = likeHelper(false);
   const removeLike = likeHelper(true);
+
+  /**
+   * showPhotoCarousel – Opens the photo carousel modal with the provided photos and start index.
+   *
+   * @remarks
+   * This function sets the photos and start index for the photo carousel and then opens the carousel modal.
+   * If no photos are provided, it defaults to showing no photos.
+   *
+   * @param {readonly string[]} [photos] – The array of photo URLs to display in the carousel.
+   * @param {number} [startIndex] – The index of the photo to start the carousel from.
+   * @return {void} – This function does not return anything.
+   */
+  const showPhotoCarousel = (photos: readonly string[] = [], startIndex: number = 0) => {
+    setCarouselPhotos(photos);
+    setCarouselStartIndex(startIndex);
+    setCarouselOpen(true);
+  };
+
+  const Modals = (
+    <>
+      <PhotoCarousel
+        photos={carouselPhotos}
+        open={carouselOpen}
+        onClose={() => setCarouselOpen(false)}
+        startIndex={carouselStartIndex}
+      />
+    </>
+  );
 
   return (
     <div className={background}>
@@ -351,6 +383,7 @@ const BookmarksPage = ({ user, setUser }: Props): ReactElement => {
                       removeLike={removeLike}
                       setToggle={setToggle}
                       triggerEditToast={showEditSuccessConfirmationToast}
+                      triggerPhotoCarousel={showPhotoCarousel}
                       user={user}
                       setUser={setUser}
                       showLabel={true}
@@ -378,6 +411,7 @@ const BookmarksPage = ({ user, setUser }: Props): ReactElement => {
           </Grid>
         )}
       </Grid>
+      {Modals}
     </div>
   );
 };

--- a/frontend/src/pages/BookmarksPage.tsx
+++ b/frontend/src/pages/BookmarksPage.tsx
@@ -17,6 +17,7 @@ import DropDownWithLabel from '../components/utils/DropDownWithLabel';
 import { AptSortFields, sortApartments } from '../utils/sortApartments';
 import Toast from '../components/utils/Toast';
 import PhotoCarousel from '../components/PhotoCarousel/PhotoCarousel';
+import usePhotoCarousel from '../components/PhotoCarousel/usePhotoCarousel';
 
 type Props = {
   user: firebase.User | null;
@@ -109,9 +110,13 @@ const BookmarksPage = ({ user, setUser }: Props): ReactElement => {
   const [showMoreLessState, setShowMoreLessState] = useState<string>('Show More');
   const [isMobile, setIsMobile] = useState<boolean>(false);
   const [showEditSuccessConfirmation, setShowEditSuccessConfirmation] = useState(false);
-  const [carouselOpen, setCarouselOpen] = useState(false);
-  const [carouselPhotos, setCarouselPhotos] = useState<readonly string[]>([]);
-  const [carouselStartIndex, setCarouselStartIndex] = useState<number>(0);
+  const {
+    carouselPhotos,
+    carouselStartIndex,
+    carouselOpen,
+    showPhotoCarousel,
+    closePhotoCarousel,
+  } = usePhotoCarousel([]);
 
   useEffect(() => {
     const handleResize = () => setIsMobile(window.innerWidth <= 600);
@@ -207,29 +212,12 @@ const BookmarksPage = ({ user, setUser }: Props): ReactElement => {
   const addLike = likeHelper(false);
   const removeLike = likeHelper(true);
 
-  /**
-   * showPhotoCarousel – Opens the photo carousel modal with the provided photos and start index.
-   *
-   * @remarks
-   * This function sets the photos and start index for the photo carousel and then opens the carousel modal.
-   * If no photos are provided, it defaults to showing no photos.
-   *
-   * @param {readonly string[]} [photos] – The array of photo URLs to display in the carousel.
-   * @param {number} [startIndex] – The index of the photo to start the carousel from.
-   * @return {void} – This function does not return anything.
-   */
-  const showPhotoCarousel = (photos: readonly string[] = [], startIndex: number = 0) => {
-    setCarouselPhotos(photos);
-    setCarouselStartIndex(startIndex);
-    setCarouselOpen(true);
-  };
-
   const Modals = (
     <>
       <PhotoCarousel
         photos={carouselPhotos}
         open={carouselOpen}
-        onClose={() => setCarouselOpen(false)}
+        onClose={closePhotoCarousel}
         startIndex={carouselStartIndex}
       />
     </>

--- a/frontend/src/pages/LandlordPage.tsx
+++ b/frontend/src/pages/LandlordPage.tsx
@@ -93,6 +93,8 @@ const LandlordPage = ({ user, setUser }: Props): ReactElement => {
   const [likeStatuses, setLikeStatuses] = useState<Likes>({});
   const [reviewOpen, setReviewOpen] = useState(false);
   const [carouselOpen, setCarouselOpen] = useState(false);
+  const [carouselPhotos, setCarouselPhotos] = useState<readonly string[]>([]);
+  const [carouselStartIndex, setCarouselStartIndex] = useState<number>(0);
   const [showConfirmation, setShowConfirmation] = useState(false);
   const [showEditSuccessConfirmation, setShowEditSuccessConfirmation] = useState(false);
   const [buildings, setBuildings] = useState<CardData[]>([]);
@@ -287,6 +289,26 @@ const LandlordPage = ({ user, setUser }: Props): ReactElement => {
     setReviewOpen(true);
   };
 
+  /**
+   * showPhotoCarousel – Opens the photo carousel modal with the provided photos and start index.
+   *
+   * @remarks
+   * This function sets the photos and start index for the photo carousel and then opens the carousel modal.
+   * If no photos are provided, it defaults to the landlord's photos.
+   *
+   * @param {readonly string[]} [photos] – The array of photo URLs to display in the carousel.
+   * @param {number} [startIndex] – The index of the photo to start the carousel from.
+   * @return {void} – This function does not return anything.
+   */
+  const showPhotoCarousel = (
+    photos: readonly string[] = landlordData ? landlordData.photos : [],
+    startIndex: number = 0
+  ) => {
+    setCarouselPhotos(photos);
+    setCarouselStartIndex(startIndex);
+    setCarouselOpen(true);
+  };
+
   // Define a component 'Modals' conditionally based on landlordData existence
   const Modals = landlordData && (
     <>
@@ -302,8 +324,9 @@ const LandlordPage = ({ user, setUser }: Props): ReactElement => {
         user={user}
       />
       <PhotoCarousel
-        photos={landlordData.photos}
+        photos={carouselPhotos}
         open={carouselOpen}
+        startIndex={carouselStartIndex}
         onClose={() => setCarouselOpen(false)}
       />
     </>
@@ -549,6 +572,7 @@ const LandlordPage = ({ user, setUser }: Props): ReactElement => {
                       removeLike={removeLike}
                       setToggle={setToggle}
                       triggerEditToast={showEditSuccessConfirmationToast}
+                      triggerPhotoCarousel={showPhotoCarousel}
                       user={user}
                       setUser={setUser}
                       showLabel={true}

--- a/frontend/src/pages/LandlordPage.tsx
+++ b/frontend/src/pages/LandlordPage.tsx
@@ -12,6 +12,7 @@ import React, { ReactElement, useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import ReviewModal from '../components/LeaveReview/ReviewModal';
 import PhotoCarousel from '../components/PhotoCarousel/PhotoCarousel';
+import usePhotoCarousel from '../components/PhotoCarousel/usePhotoCarousel';
 import InfoFeatures from '../components/Review/InfoFeatures';
 import ReviewComponent from '../components/Review/Review';
 import ReviewHeader from '../components/Review/ReviewHeader';
@@ -92,9 +93,13 @@ const LandlordPage = ({ user, setUser }: Props): ReactElement => {
   const [likedReviews, setLikedReviews] = useState<Likes>({});
   const [likeStatuses, setLikeStatuses] = useState<Likes>({});
   const [reviewOpen, setReviewOpen] = useState(false);
-  const [carouselOpen, setCarouselOpen] = useState(false);
-  const [carouselPhotos, setCarouselPhotos] = useState<readonly string[]>([]);
-  const [carouselStartIndex, setCarouselStartIndex] = useState<number>(0);
+  const {
+    carouselPhotos,
+    carouselStartIndex,
+    carouselOpen,
+    showPhotoCarousel,
+    closePhotoCarousel,
+  } = usePhotoCarousel(landlordData ? landlordData.photos : []);
   const [showConfirmation, setShowConfirmation] = useState(false);
   const [showEditSuccessConfirmation, setShowEditSuccessConfirmation] = useState(false);
   const [buildings, setBuildings] = useState<CardData[]>([]);
@@ -289,26 +294,6 @@ const LandlordPage = ({ user, setUser }: Props): ReactElement => {
     setReviewOpen(true);
   };
 
-  /**
-   * showPhotoCarousel – Opens the photo carousel modal with the provided photos and start index.
-   *
-   * @remarks
-   * This function sets the photos and start index for the photo carousel and then opens the carousel modal.
-   * If no photos are provided, it defaults to the landlord's photos.
-   *
-   * @param {readonly string[]} [photos] – The array of photo URLs to display in the carousel.
-   * @param {number} [startIndex] – The index of the photo to start the carousel from.
-   * @return {void} – This function does not return anything.
-   */
-  const showPhotoCarousel = (
-    photos: readonly string[] = landlordData ? landlordData.photos : [],
-    startIndex: number = 0
-  ) => {
-    setCarouselPhotos(photos);
-    setCarouselStartIndex(startIndex);
-    setCarouselOpen(true);
-  };
-
   // Define a component 'Modals' conditionally based on landlordData existence
   const Modals = landlordData && (
     <>
@@ -327,7 +312,7 @@ const LandlordPage = ({ user, setUser }: Props): ReactElement => {
         photos={carouselPhotos}
         open={carouselOpen}
         startIndex={carouselStartIndex}
-        onClose={() => setCarouselOpen(false)}
+        onClose={closePhotoCarousel}
       />
     </>
   );
@@ -365,7 +350,7 @@ const LandlordPage = ({ user, setUser }: Props): ReactElement => {
             color="secondary"
             variant="contained"
             disableElevation
-            onClick={() => setCarouselOpen(true)}
+            onClick={() => showPhotoCarousel()}
           >
             Show all photos
           </Button>
@@ -463,7 +448,7 @@ const LandlordPage = ({ user, setUser }: Props): ReactElement => {
               color="secondary"
               variant="contained"
               disableElevation
-              onClick={() => setCarouselOpen(true)}
+              onClick={() => showPhotoCarousel()}
             >
               Show all photos
             </Button>
@@ -523,7 +508,7 @@ const LandlordPage = ({ user, setUser }: Props): ReactElement => {
     <>
       {landlordData && (
         <Container>
-          <LandlordHeader landlord={landlordData} handleClick={() => setCarouselOpen(true)} />
+          <LandlordHeader landlord={landlordData} handleClick={() => showPhotoCarousel()} />
         </Container>
       )}
 

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -21,6 +21,7 @@ import { createAuthHeaders, getUser } from '../utils/firebase';
 import defaultProfilePic from '../assets/cuapts-bear.png';
 import { useTitle } from '../utils';
 import { sortReviews } from '../utils/sortReviews';
+import PhotoCarousel from '../components/PhotoCarousel/PhotoCarousel';
 
 type Props = {
   user: firebase.User | null;
@@ -166,6 +167,9 @@ const ProfilePage = ({ user, setUser }: Props): ReactElement => {
   const [toggle, setToggle] = useState(false);
   const [showEditSuccessConfirmation, setShowEditSuccessConfirmation] = useState(false);
   const toastTime = 3500;
+  const [carouselOpen, setCarouselOpen] = useState(false);
+  const [carouselPhotos, setCarouselPhotos] = useState<readonly string[]>([]);
+  const [carouselStartIndex, setCarouselStartIndex] = useState<number>(0);
 
   useTitle('Profile');
 
@@ -256,6 +260,34 @@ const ProfilePage = ({ user, setUser }: Props): ReactElement => {
     };
   }, [isModalOpen, setIsModalOpen]);
 
+  /**
+   * showPhotoCarousel – Opens the photo carousel modal with the provided photos and start index.
+   *
+   * @remarks
+   * This function sets the photos and start index for the photo carousel and then opens the carousel modal.
+   * If no photos are provided, it defaults to showing no photos.
+   *
+   * @param {readonly string[]} [photos] – The array of photo URLs to display in the carousel.
+   * @param {number} [startIndex] – The index of the photo to start the carousel from.
+   * @return {void} – This function does not return anything.
+   */
+  const showPhotoCarousel = (photos: readonly string[] = [], startIndex: number = 0) => {
+    setCarouselPhotos(photos);
+    setCarouselStartIndex(startIndex);
+    setCarouselOpen(true);
+  };
+
+  const Modals = (
+    <>
+      <PhotoCarousel
+        photos={carouselPhotos}
+        open={carouselOpen}
+        onClose={() => setCarouselOpen(false)}
+        startIndex={carouselStartIndex}
+      />
+    </>
+  );
+
   return (
     <div className={root}>
       <Grid container spacing={2} className={gridContainer}>
@@ -324,6 +356,7 @@ const ProfilePage = ({ user, setUser }: Props): ReactElement => {
                   removeLike={removeLike}
                   setToggle={setToggle}
                   triggerEditToast={showEditSuccessConfirmationToast}
+                  triggerPhotoCarousel={showPhotoCarousel}
                   user={user}
                   setUser={setUser}
                   showLabel={true}
@@ -345,6 +378,7 @@ const ProfilePage = ({ user, setUser }: Props): ReactElement => {
                   removeLike={removeLike}
                   setToggle={setToggle}
                   triggerEditToast={showEditSuccessConfirmationToast}
+                  triggerPhotoCarousel={showPhotoCarousel}
                   user={user}
                   setUser={setUser}
                   showLabel={true}
@@ -369,6 +403,7 @@ const ProfilePage = ({ user, setUser }: Props): ReactElement => {
           </div>
         )}
       </div>
+      {Modals}
     </div>
   );
 };

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -22,6 +22,7 @@ import defaultProfilePic from '../assets/cuapts-bear.png';
 import { useTitle } from '../utils';
 import { sortReviews } from '../utils/sortReviews';
 import PhotoCarousel from '../components/PhotoCarousel/PhotoCarousel';
+import usePhotoCarousel from '../components/PhotoCarousel/usePhotoCarousel';
 
 type Props = {
   user: firebase.User | null;
@@ -167,9 +168,13 @@ const ProfilePage = ({ user, setUser }: Props): ReactElement => {
   const [toggle, setToggle] = useState(false);
   const [showEditSuccessConfirmation, setShowEditSuccessConfirmation] = useState(false);
   const toastTime = 3500;
-  const [carouselOpen, setCarouselOpen] = useState(false);
-  const [carouselPhotos, setCarouselPhotos] = useState<readonly string[]>([]);
-  const [carouselStartIndex, setCarouselStartIndex] = useState<number>(0);
+  const {
+    carouselPhotos,
+    carouselStartIndex,
+    carouselOpen,
+    showPhotoCarousel,
+    closePhotoCarousel,
+  } = usePhotoCarousel([]);
 
   useTitle('Profile');
 
@@ -260,29 +265,12 @@ const ProfilePage = ({ user, setUser }: Props): ReactElement => {
     };
   }, [isModalOpen, setIsModalOpen]);
 
-  /**
-   * showPhotoCarousel – Opens the photo carousel modal with the provided photos and start index.
-   *
-   * @remarks
-   * This function sets the photos and start index for the photo carousel and then opens the carousel modal.
-   * If no photos are provided, it defaults to showing no photos.
-   *
-   * @param {readonly string[]} [photos] – The array of photo URLs to display in the carousel.
-   * @param {number} [startIndex] – The index of the photo to start the carousel from.
-   * @return {void} – This function does not return anything.
-   */
-  const showPhotoCarousel = (photos: readonly string[] = [], startIndex: number = 0) => {
-    setCarouselPhotos(photos);
-    setCarouselStartIndex(startIndex);
-    setCarouselOpen(true);
-  };
-
   const Modals = (
     <>
       <PhotoCarousel
         photos={carouselPhotos}
         open={carouselOpen}
-        onClose={() => setCarouselOpen(false)}
+        onClose={closePhotoCarousel}
         startIndex={carouselStartIndex}
       />
     </>


### PR DESCRIPTION
### Summary <!-- Required -->

The photo previews in reviews are small, making it difficult to check if a photo is appropriate as an admin and difficult for users to view. This pull request extends the usage of the PhotoCarousel component to support review photo previews and different starting indexes.

- [x] Refactor the PhotoCarousel component to update the styling to handle large photos.
- [x] Add functionality to the PhotoCarousel component to display a carousel with a different start index
- [x] The PhotoCarousel component now accepts a start index as a prop.
- [x] Clicking on a photo in the Review and AdminReview components triggers the photo carousel with the corresponding photos and start index.
- [x] Added hover effects and cursor adjustment to indicate the photos are expandable.  
- [x] Added documentation for PhotoCarousel and showPhotoCarousel 
- [x] Created usePhotoCarousel with functions and states to avoid code duplication. 
- [x] Fixed styling issues with the photo carousel.
- [x] Improved loading speeds when processing large images by using lazy loading
- [x] Fixed onClose functionality to close the modal

### Test Plan <!-- Required -->

I tested the review pop up on all pages with review components or admin review components, including AdminPage, ApartmentPage, BookmarksPage, LandlordPage, ProfilePage. I tested it on large vertical and horizontal photos to make sure buttons remain on the screen. I also tested responsiveness across mobile and desktop devices. I also tested the photo carousel still works on previewing apartment photos to ensure backward compatibility. 

<!-- Provide screenshots or point out the additional unit tests -->
Desktop
<img width="1280" alt="Screenshot 2024-10-24 at 11 10 21 AM" src="https://github.com/user-attachments/assets/7bf07ac1-9ba5-4c71-9ca0-c73e38ab4fa4">
Mobile
<img width="289" alt="Screenshot 2024-10-24 at 11 10 51 AM" src="https://github.com/user-attachments/assets/8c45e0d6-8e35-404a-a5d0-a89074a0a8ac">
Desktop
<img width="1278" alt="Screenshot 2024-10-24 at 11 11 16 AM" src="https://github.com/user-attachments/assets/da5ea3ee-b93c-420e-a566-26893bd650cc">
Mobile
<img width="290" alt="Screenshot 2024-10-24 at 11 11 35 AM" src="https://github.com/user-attachments/assets/6f9411e3-ca17-4546-89ae-225f986224f7">

### Notes <!-- Optional -->

- Hover effects can be discussed in more detail. Currently, it expands in size and darkens.