### PR TITLE
Converted save image button

### DIFF
--- a/frontend/src/pages/ApartmentPage.tsx
+++ b/frontend/src/pages/ApartmentPage.tsx
@@ -39,8 +39,8 @@ import { getAverageRating } from '../utils/average';
 import { colors } from '../colors';
 import clsx from 'clsx';
 import { sortReviews } from '../utils/sortReviews';
-import savedIcon from '../assets/filled-large-saved-icon.png';
-import unsavedIcon from '../assets/unfilled-large-saved-icon.png';
+import savedIcon from '../assets/saved-icon-filled.svg';
+import unsavedIcon from '../assets/saved-icon-unfilled.svg';
 import MapModal from '../components/Apartment/MapModal';
 import DropDownWithLabel from '../components/utils/DropDownWithLabel';
 
@@ -77,9 +77,6 @@ const useStyles = makeStyles((theme) => ({
   container: {
     marginTop: '20px',
   },
-  root: {
-    borderRadius: '10px',
-  },
   expand: {
     transform: 'rotate(0deg)',
     marginLeft: 'auto',
@@ -88,22 +85,22 @@ const useStyles = makeStyles((theme) => ({
   expandOpen: {
     transform: 'rotate(180deg)',
   },
-  dateText: {
-    color: colors.gray1,
-  },
-  button: {
-    textTransform: 'none',
-    '&.Mui-disabled': {
-      color: 'inherit',
+  saveButton: {
+    backgroundColor: 'transparent',
+    width: '107px',
+    margin: '10px 16px',
+    borderRadius: '30px',
+    border: '2px solid',
+    fontSize: '15px',
+    borderColor: colors.red1,
+    '&:focus': {
+      borderColor: `${colors.red1} !important`,
     },
   },
-  horizontalLine: {
-    borderTop: '1px solid #C4C4C4',
-    width: '95%',
-    marginTop: '20px',
-    borderLeft: 'none',
-    borderRight: 'none',
-    borderBottom: 'none',
+  bookmarkRibbon: {
+    width: '19px',
+    height: '25px',
+    marginRight: '10px',
   },
 }));
 
@@ -174,6 +171,8 @@ const ApartmentPage = ({ user, setUser }: Props): ReactElement => {
     container,
     expand,
     expandOpen,
+    saveButton,
+    bookmarkRibbon,
   } = useStyles();
 
   // Set the page title based on whether apartment data is loaded.
@@ -438,7 +437,7 @@ const ApartmentPage = ({ user, setUser }: Props): ReactElement => {
           )}
 
           <Grid item style={{ marginLeft: 'auto' }}>
-            <IconButton
+            {/* <IconButton
               disableRipple
               onClick={handleSaveToggle}
               style={{
@@ -451,7 +450,19 @@ const ApartmentPage = ({ user, setUser }: Props): ReactElement => {
                 alt={isSaved ? 'Saved' : 'Unsaved'}
                 style={{ width: '107px', height: '43px' }}
               />
-            </IconButton>
+            </IconButton> */}
+            <Button
+              disableRipple
+              onClick={handleSaveToggle}
+              className={saveButton}
+              color="primary"
+              variant="outlined"
+              fullWidth
+              disableElevation
+            >
+              <img src={isSaved ? saved : unsaved} className={bookmarkRibbon} />
+              {isSaved ? 'Saved' : 'Save'}
+            </Button>
             <Button
               color="primary"
               className={reviewButton}

--- a/frontend/src/pages/ApartmentPage.tsx
+++ b/frontend/src/pages/ApartmentPage.tsx
@@ -456,7 +456,6 @@ const ApartmentPage = ({ user, setUser }: Props): ReactElement => {
               onClick={handleSaveToggle}
               className={saveButton}
               color="primary"
-              variant="outlined"
               fullWidth
               disableElevation
             >


### PR DESCRIPTION
### Summary <!-- Required -->

This pull request fixes the bug where our save apartment button is an image and not an actual button as requested by PM.

- [x] Converted save apartment image button to normal button component

### Test Plan <!-- Required -->
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/5fda9fe4-dc1c-4f53-9c82-0db6c81a5674">
Apartment when saved:
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/feb6b946-6c2e-4e84-a8a6-ed3508a5be22">

### Notes <!-- Optional -->

- Currently, on mobile there is no way to actually save the apartment. I tried playing around with different locations to put a bookmark icon button but the space is quite cramped and the different versions I tried out made the UI too cluttered or too small, I'm going to ask designers about their opinions on where we can add the save button on mobile.
