### PR TITLE
WIP: Fixing Self-like Bug on Reviews

### DIFF
--- a/frontend/src/components/Review/Review.tsx
+++ b/frontend/src/components/Review/Review.tsx
@@ -46,6 +46,7 @@ import getPriceRange from '../../utils/priceRange';
 import OptionMenu from '../utils/OptionMenu';
 import { ReactComponent as BedIcon } from '../../assets/bed-icon.svg';
 import { ReactComponent as MoneyIcon } from '../../assets/money-icon.svg';
+import { exists } from 'fs';
 
 type Props = {
   readonly review: ReviewWithId;
@@ -464,9 +465,19 @@ const ReviewComponent = ({
     }
   };
 
+  /**
+   * likeHandler - Adds a like to a comment after clicking the like button
+   *
+   * @remarks A user is not allowed to like their own comment, hence the extra identification in
+   * the method to ensure the comment wasn't created by the current user.
+   *
+   * @param {Number} id - Id of the comment who's like counter is being added to.
+   */
   const likeHandler = async (id: string) => {
     if (user) {
-      (liked ? removeLike : addLike)(id);
+      if (!(review.userId != null && review.userId == user.uid)) {
+        (liked ? removeLike : addLike)(id);
+      }
     } else {
       let user = await getUser(true);
       setUser(user);


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request is a work in progress and attempts to fix a bug where users could like their own comment. This was fixed by adjusting the previously existing "likeHandler" function to include more requirements for a "like" on a comment to be performed. Unit tests still need to be performed for this PR.

- [x] Fixed the "likeHandler" method to stop users from liking their own reviews
- [ ] Created unit tests for "likeHandler" function

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
To test this PR out, two users are required. One user is required to create a comment and attempt to like it, while a separate user is required to like the same comment.
<img width="1512" alt="Screenshot 2025-02-09 at 11 49 53 PM" src="https://github.com/user-attachments/assets/a55c94d2-15ff-452e-b04b-d783ce5a4050" />
The first half of this test has been completed where a user can not like their own comment. However, a separate user is still needed to check if the like button still works.

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes  <!-- Optional -->

<!-- Keep items that apply: -->
- Database schema change (anything that changes Firestore collection structure)
- Other change that could cause problems (Detailed in notes)