### PR TITLE
Implemented Apartment Map Building Icons and Names

### DIFF
--- a/frontend/src/components/Apartment/MapInfo.tsx
+++ b/frontend/src/components/Apartment/MapInfo.tsx
@@ -10,7 +10,6 @@ import blackPinIcon from '../../assets/ph_map-pin-fill.svg';
 import { config } from 'dotenv';
 import { Marker } from './Marker';
 import { LocationTravelTimes } from '../../../../common/types/db-types';
-import { fstat } from 'fs';
 
 config();
 

--- a/frontend/src/components/Apartment/MapInfo.tsx
+++ b/frontend/src/components/Apartment/MapInfo.tsx
@@ -10,6 +10,7 @@ import blackPinIcon from '../../assets/ph_map-pin-fill.svg';
 import { config } from 'dotenv';
 import { Marker } from './Marker';
 import { LocationTravelTimes } from '../../../../common/types/db-types';
+import { fstat } from 'fs';
 
 config();
 
@@ -192,6 +193,14 @@ function MapInfo({
               options={{
                 fullscreenControl: false,
                 zoomControl: false,
+                clickableIcons: false,
+                styles: [
+                  {
+                    featureType: 'poi',
+                    elementType: 'labels',
+                    stylers: [{ visibility: 'on' }],
+                  },
+                ],
               }}
             >
               <Marker lat={latitude} lng={longitude} src={aptIcon} altText="apartment icon" />

--- a/frontend/src/components/Apartment/MapModal.tsx
+++ b/frontend/src/components/Apartment/MapModal.tsx
@@ -281,6 +281,14 @@ const MapModal = ({
                 options={{
                   fullscreenControl: false,
                   zoomControl: false,
+                  clickableIcons: true,
+                  styles: [
+                    {
+                      featureType: 'poi',
+                      elementType: 'labels',
+                      stylers: [{ visibility: 'on' }],
+                    },
+                  ],
                 }}
               >
                 <Marker lat={latitude} lng={longitude} src={aptIcon} altText="apartment icon" />


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request is the first step towards implementing feature Foo

- [x] Switched on building icons and names for google map api display in mapInfo and mapModal
- [x] Clickable icons in map modal mode 

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

<img width="419" alt="apartment-map-building-names" src="https://github.com/user-attachments/assets/ef9423a2-0b8a-4ed2-87a7-bccd9ebb4847" />

- Apartment map building names and icons

<img width="1440" alt="map-modal-building-icons" src="https://github.com/user-attachments/assets/07528592-ced9-4ac9-9298-93719129a75f" />

- Apartment map modal building names and icons

<img width="527" alt="map-modal-clickable-icons" src="https://github.com/user-attachments/assets/9a21063d-83ef-4f85-b79f-fea7833fbd46" />

- Apartment map modal clickable building icons 


### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->
- Building icons are currently not clickable for map (only for map modal mode)
- Different types of building name/icon visibilities could be customized based on design needs