### PR TITLE
Fix engines.node: >=18 → 18.x for Heroku compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@types/react": "^17.0.80"
   },
   "engines": {
-    "node": ">=18"
+    "node": "18.x"
   },
   "dependencies": {
     "@date-io/date-fns": "^1.3.13",


### PR DESCRIPTION
### Summary                                                                                                       
  - Fix `engines.node` from `>=18` to `18.x` — Heroku rejects the `>=` operator in the engines field
                                                                                                                    
  ### Test Plan                                             
  Redeploy to `cuapts-staging` after merge — build should succeed.                                                  
                                                                                                                    
  ### Notes
  `>=18` was introduced in the previous PR (#418). `18.x` is equivalent and accepted by Heroku's Node.js buildpack. 
                   