### PR TITLE
Fix Heroku build failure: add NODE_OPTIONS to build script for Node 18 compatibility

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,7 +35,7 @@
   "scripts": {
     "start": "NODE_OPTIONS=--openssl-legacy-provider env-cmd -f ../.env.dev react-scripts start",
     "start-prod": "env-cmd -f ../.env.prod react-scripts start",
-    "build": "react-scripts build",
+    "build": "NODE_OPTIONS=--openssl-legacy-provider react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "lint": "eslint . --ext .ts --ext .tsx",


### PR DESCRIPTION
### Summary                                                   
                                                                                                                    
  - Added NODE_OPTIONS=--openssl-legacy-provider to the build script in frontend/package.json                       
                                                                                                                    
  webpack 4 (bundled with react-scripts 4) uses legacy OpenSSL digest algorithms unsupported in Node 18. The start  
  script already had this flag, but the build script was missing it, causing ERR_OSSL_EVP_UNSUPPORTED on Heroku.
                                                                                                                    
  ### Test Plan                                                 

  Heroku staging build succeeded after setting NODE_OPTIONS=--openssl-legacy-provider as a config var (equivalent   
  workaround). This PR makes the fix permanent in code so the config var is no longer needed.
                                                                                                                    
  ### Notes                                                     

  The Heroku config var NODE_OPTIONS=--openssl-legacy-provider can be removed after this merges — it will be        
  redundant. This is a short-term fix; long-term solution is upgrading to react-scripts 5 or Vite (tracked in TODO).
                                                                             