### PR TITLE
Tag feature

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -35,8 +35,11 @@
   "devDependencies": {
     "@types/cors": "^2.8.10",
     "@types/express": "^4.17.11",
+    "@types/jest": "^26.0.15",
     "@types/morgan": "^1.9.2",
     "@types/supertest": "^2.0.11",
-    "eslint-import-resolver-typescript": "^2.5.0"
+    "eslint-import-resolver-typescript": "^2.5.0",
+    "jest": "^26.6.0",
+    "ts-jest": "^26.5.3"
   }
 }

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,6 +7,7 @@
     "add_buildings": "ts-node scripts/add_buildings.ts",
     "add_landlords": "ts-node scripts/add_landlords.ts",
     "add_reviews": "ts-node scripts/add_reviews_nodups.ts",
+    "seed_example_tags": "env-cmd -f ../.env.dev ts-node scripts/seed_example_tags.ts",
     "build": "tsc",
     "tsc": "tsc",
     "start": "node dist/backend/src/server.js",

--- a/backend/scripts/seed_example_tags.ts
+++ b/backend/scripts/seed_example_tags.ts
@@ -1,0 +1,146 @@
+import { db } from '../src/firebase-config';
+
+const EXAMPLE_TAG_NAMES = ['Best value', 'Close to campus', 'Most reviewed'] as const;
+
+const TOP_N = 2;
+
+type TagKey = 'best' | 'close' | 'reviewed';
+
+const TAG_NAME_TO_KEY: Record<typeof EXAMPLE_TAG_NAMES[number], TagKey> = {
+  'Best value': 'best',
+  'Close to campus': 'close',
+  'Most reviewed': 'reviewed',
+};
+
+const KEY_LABEL: Record<TagKey, string> = {
+  best: 'best value',
+  close: 'close to campus',
+  reviewed: 'most reviewed',
+};
+
+async function getOrCreateTagId(name: typeof EXAMPLE_TAG_NAMES[number]): Promise<string> {
+  const trimmed = name.trim();
+  const normalizedName = trimmed.toLowerCase();
+  const existing = await db.collection('tags').where('normalizedName', '==', normalizedName).get();
+  if (!existing.empty) {
+    return existing.docs[0].id;
+  }
+  const ref = db.collection('tags').doc();
+  await ref.set({ name: trimmed, normalizedName });
+  return ref.id;
+}
+
+async function countApprovedReviewsByApt(): Promise<Map<string, number>> {
+  const map = new Map<string, number>();
+  const revs = await db.collection('reviews').where('status', '==', 'APPROVED').get();
+  revs.forEach((doc) => {
+    const data = doc.data();
+    const aid = data.aptId;
+    if (typeof aid === 'string' && aid.length > 0) {
+      map.set(aid, (map.get(aid) || 0) + 1);
+    }
+  });
+  return map;
+}
+
+const main = async () => {
+  const tagIdByKey: Record<TagKey, string> = {
+    best: '',
+    close: '',
+    reviewed: '',
+  };
+
+  const tagEntries = await Promise.all(
+    EXAMPLE_TAG_NAMES.map((name) => getOrCreateTagId(name).then((id) => ({ name, id } as const)))
+  );
+  tagEntries.forEach(({ name, id }) => {
+    const key = TAG_NAME_TO_KEY[name];
+    tagIdByKey[key] = id;
+    console.log(`[tag] ${KEY_LABEL[key]}: ${id}`);
+  });
+
+  const snap = await db.collection('buildings').get();
+  const rows = snap.docs.map((d) => {
+    const data = d.data();
+    return {
+      id: d.id,
+      distanceToCampus:
+        typeof data.distanceToCampus === 'number'
+          ? data.distanceToCampus
+          : Number.POSITIVE_INFINITY,
+      price: typeof data.price === 'number' ? data.price : Number.POSITIVE_INFINITY,
+    };
+  });
+
+  if (rows.length === 0) {
+    console.log('No buildings in Firestore; only tags were created/verified.');
+    return;
+  }
+
+  const reviewCounts = await countApprovedReviewsByApt();
+
+  const byDistance = [...rows].sort((a, b) => a.distanceToCampus - b.distanceToCampus);
+  const finiteDistance = byDistance.filter((b) => Number.isFinite(b.distanceToCampus));
+  let closeToCampus = finiteDistance
+    .slice(0, Math.min(TOP_N, finiteDistance.length))
+    .map((b) => b.id);
+  if (closeToCampus.length === 0) {
+    closeToCampus = byDistance.slice(0, Math.min(TOP_N, byDistance.length)).map((b) => b.id);
+  }
+
+  const closeSet = new Set(closeToCampus);
+  const pricePool = rows.filter((b) => b.price > 0);
+  const sortByPrice = pricePool.length >= Math.min(TOP_N, rows.length) ? pricePool : rows;
+  const byPriceAsc = [...sortByPrice].sort((a, b) => a.price - b.price);
+  const bestOutsideClose = byPriceAsc.filter((b) => !closeSet.has(b.id));
+  const bestValuePool = bestOutsideClose.length >= TOP_N ? bestOutsideClose : byPriceAsc;
+  const bestValue = bestValuePool.slice(0, Math.min(TOP_N, bestValuePool.length)).map((b) => b.id);
+
+  const bestSet = new Set<string>([...closeToCampus, ...bestValue]);
+  const reviewedWithCount = rows
+    .map((b) => ({ id: b.id, c: reviewCounts.get(b.id) || 0 }))
+    .filter((x) => x.c > 0)
+    .sort((a, b) => b.c - a.c);
+  const reviewedOutside = reviewedWithCount.filter((x) => !bestSet.has(x.id));
+  const mostReviewedPool = reviewedOutside.length >= TOP_N ? reviewedOutside : reviewedWithCount;
+  const mostReviewed = mostReviewedPool.slice(0, TOP_N).map((x) => x.id);
+
+  const toApply = new Map<string, Set<TagKey>>();
+
+  const add = (aptId: string, key: TagKey) => {
+    let keySet = toApply.get(aptId);
+    if (!keySet) {
+      keySet = new Set<TagKey>();
+      toApply.set(aptId, keySet);
+    }
+    keySet.add(key);
+  };
+
+  closeToCampus.forEach((id) => add(id, 'close'));
+  bestValue.forEach((id) => add(id, 'best'));
+  mostReviewed.forEach((id) => add(id, 'reviewed'));
+
+  console.log(
+    `[heuristic] close to campus: ${closeToCampus.length} apts, best value: ${bestValue.length}, most reviewed: ${mostReviewed.length}`
+  );
+
+  await Promise.all(
+    Array.from(toApply.entries()).map(async ([aptId, keys]) => {
+      const ref = db.collection('buildings').doc(aptId);
+      const cur = (await ref.get()).data() as { tags?: string[] } | undefined;
+      const existing: string[] = cur && Array.isArray(cur.tags) ? [...cur.tags] : [];
+      const newIds = Array.from(keys).map((k: TagKey) => tagIdByKey[k]);
+      const merged = Array.from(new Set([...existing, ...newIds]));
+      await ref.update({ tags: merged });
+      const labels = Array.from(keys).map((k) => KEY_LABEL[k]);
+      console.log(`[building] ${aptId} +tags (${labels.join(', ')})`);
+    })
+  );
+
+  console.log('Done. Refresh the app; search and listings read tags from Firestore.');
+};
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -12,6 +12,7 @@ import {
   LandlordWithLabel,
   ApartmentWithLabel,
   ApartmentWithId,
+  TagWithId,
   CantFindApartmentForm,
   CantFindApartmentFormWithId,
   QuestionForm,
@@ -38,6 +39,7 @@ const cuaptsEmailPassword = process.env.CUAPTS_EMAIL_APP_PASSWORD;
 const reviewCollection = db.collection('reviews');
 const landlordCollection = db.collection('landlords');
 const buildingsCollection = db.collection('buildings');
+const tagsCollection = db.collection('tags');
 const likesCollection = db.collection('likes');
 const usersCollection = db.collection('users');
 const pendingBuildingsCollection = db.collection('pendingBuildings');
@@ -66,6 +68,34 @@ app.get('/api/faqs', async (_, res) => {
   });
 
   res.status(200).send(JSON.stringify(faqs));
+});
+
+// API endpoint to create a new tag (or return existing)
+app.post('/api/tags', async (req, res) => {
+  try {
+    const { name } = req.body as { name?: unknown };
+    if (typeof name !== 'string' || name.trim().length === 0) {
+      res.status(400).send('Error: invalid tag name');
+      return;
+    }
+
+    const trimmedName = name.trim();
+    const normalizedName = trimmedName.toLowerCase();
+
+    const existing = await tagsCollection.where('normalizedName', '==', normalizedName).get();
+    if (!existing.empty) {
+      const doc = existing.docs[0];
+      res.status(200).send(JSON.stringify({ id: doc.id, name: doc.data()?.name } as TagWithId));
+      return;
+    }
+
+    const doc = tagsCollection.doc();
+    await doc.set({ name: trimmedName, normalizedName });
+    res.status(200).send(JSON.stringify({ id: doc.id, name: trimmedName } as TagWithId));
+  } catch (err) {
+    console.error(err);
+    res.status(400).send('Error');
+  }
 });
 
 // API endpoint to post a new review
@@ -271,6 +301,95 @@ app.get('/api/apts/:ids', async (req, res) => {
     res.status(200).send(JSON.stringify(aptsArr));
   } catch (err) {
     res.status(400).send(err);
+  }
+});
+
+// API endpoint to get tags for a specific apartment
+app.get('/api/apts/:id/tags', async (req, res) => {
+  try {
+    const { id } = req.params;
+    const snapshot = await buildingsCollection.doc(id).get();
+    if (!snapshot.exists) {
+      res.status(400).send('Invalid id');
+      return;
+    }
+
+    const tags = snapshot.data()?.tags as readonly string[] | undefined;
+    if (!tags || tags.length === 0) {
+      res.status(200).send(JSON.stringify([]));
+      return;
+    }
+
+    const tagDocs = await Promise.all(
+      tags.map(async (tagId) => [tagId, await tagsCollection.doc(tagId).get()] as const)
+    );
+    const result: TagWithId[] = tagDocs
+      .filter(([, doc]) => doc.exists)
+      .map(([tagId, doc]) => ({ id: tagId, name: doc.data()?.name } as TagWithId))
+      .filter((tag) => typeof tag.name === 'string');
+
+    res.status(200).send(JSON.stringify(result));
+  } catch (err) {
+    console.error(err);
+    res.status(400).send('Error');
+  }
+});
+
+// API endpoint to add a tag to a specific apartment
+app.post('/api/apts/:id/tags/:tagId', async (req, res) => {
+  try {
+    const { id, tagId } = req.params;
+    const buildingRef = buildingsCollection.doc(id);
+    const buildingDoc = await buildingRef.get();
+    if (!buildingDoc.exists) {
+      res.status(400).send('Invalid id');
+      return;
+    }
+
+    const tagDoc = await tagsCollection.doc(tagId).get();
+    if (!tagDoc.exists) {
+      res.status(400).send('Invalid tag id');
+      return;
+    }
+
+    const existingTags = (buildingDoc.data()?.tags as readonly string[] | undefined) || [];
+    if (existingTags.includes(tagId)) {
+      res.status(200).send(JSON.stringify([...existingTags]));
+      return;
+    }
+
+    const updatedTags = [...existingTags, tagId];
+    await buildingRef.update({ tags: updatedTags });
+    res.status(200).send(JSON.stringify(updatedTags));
+  } catch (err) {
+    console.error(err);
+    res.status(400).send('Error');
+  }
+});
+
+// API endpoint to remove a tag from a specific apartment
+app.delete('/api/apts/:id/tags/:tagId', async (req, res) => {
+  try {
+    const { id, tagId } = req.params;
+    const buildingRef = buildingsCollection.doc(id);
+    const buildingDoc = await buildingRef.get();
+    if (!buildingDoc.exists) {
+      res.status(400).send('Invalid id');
+      return;
+    }
+
+    const existingTags = (buildingDoc.data()?.tags as readonly string[] | undefined) || [];
+    if (!existingTags.includes(tagId)) {
+      res.status(200).send(JSON.stringify([...existingTags]));
+      return;
+    }
+
+    const updatedTags = existingTags.filter((t) => t !== tagId);
+    await buildingRef.update({ tags: updatedTags });
+    res.status(200).send(JSON.stringify(updatedTags));
+  } catch (err) {
+    console.error(err);
+    res.status(400).send('Error');
   }
 });
 

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -98,6 +98,21 @@ app.post('/api/tags', async (req, res) => {
   }
 });
 
+// API endpoint to list all tags (for search and filters)
+app.get('/api/tags', async (_req, res) => {
+  try {
+    const snap = await tagsCollection.get();
+    const tags: TagWithId[] = snap.docs
+      .map((d) => ({ id: d.id, name: d.data()?.name } as TagWithId))
+      .filter((t) => typeof t.name === 'string');
+    tags.sort((a, b) => a.name.localeCompare(b.name));
+    res.status(200).send(JSON.stringify(tags));
+  } catch (err) {
+    console.error(err);
+    res.status(400).send('Error');
+  }
+});
+
 // API endpoint to post a new review
 app.post('/api/new-review', authenticate, async (req, res) => {
   try {
@@ -449,12 +464,33 @@ const pageData = async (buildings: ApartmentWithId[]) =>
       const avgPrice =
         reviewsWithPrice.reduce((acc, curr) => acc + curr.data().price, 0) /
         Math.max(reviewsWithPrice.length, 1);
+
+      const tagIds = buildingData.tags;
+      let apartmentTags: TagWithId[] = [];
+      if (tagIds && tagIds.length > 0) {
+        const tagDocs = await Promise.all(tagIds.map((tid) => tagsCollection.doc(tid).get()));
+        apartmentTags = tagIds
+          .map((tid, i) => {
+            const d = tagDocs[i];
+            if (!d.exists) {
+              return null;
+            }
+            const tagName = d.data()?.name;
+            if (typeof tagName !== 'string') {
+              return null;
+            }
+            return { id: tid, name: tagName } as TagWithId;
+          })
+          .filter((t): t is TagWithId => t != null);
+      }
+
       return {
         buildingData,
         numReviews,
         company,
         avgRating,
         avgPrice,
+        apartmentTags,
       };
     })
   );
@@ -485,6 +521,39 @@ app.post('/api/new-landlord', async (req, res) => {
 
 // Utility function to check if an object is a Landlord
 const isLandlord = (obj: LandlordWithId | ApartmentWithId): boolean => 'contact' in obj;
+
+const loadAllAptsFromFirestore = async (): Promise<ApartmentWithId[]> => {
+  const aptDocs = (await buildingsCollection.get()).docs;
+  return aptDocs.map((apt) => ({ id: apt.id, ...apt.data() } as ApartmentWithId));
+};
+
+const loadAllLandlordsFromFirestore = async (): Promise<LandlordWithId[]> => {
+  const landlordDocs = (await landlordCollection.get()).docs;
+  return landlordDocs.map((l) => ({ id: l.id, ...l.data() } as LandlordWithId));
+};
+
+const parseTagIdsQuery = (tagIds: unknown): string[] => {
+  if (typeof tagIds !== 'string' || tagIds.trim() === '') {
+    return [];
+  }
+  return tagIds
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+};
+
+const filterAptsByTagIds = (apts: ApartmentWithId[], required: string[]): ApartmentWithId[] => {
+  if (required.length === 0) {
+    return apts;
+  }
+  return apts.filter((apt) => {
+    const t = apt.tags;
+    if (!t || t.length === 0) {
+      return false;
+    }
+    return required.every((id) => t.includes(id));
+  });
+};
 
 // API endpoint to set application data (landlords and apartments)
 app.post('/api/set-data', async (req, res) => {
@@ -527,8 +596,10 @@ app.post('/api/set-data', async (req, res) => {
 app.get('/api/search', async (req, res) => {
   try {
     const query = req.query.q as string;
-    const landlords = req.app.get('landlords');
-    const apts = req.app.get('apts');
+    const [landlords, apts] = await Promise.all([
+      loadAllLandlordsFromFirestore(),
+      loadAllAptsFromFirestore(),
+    ]);
     const aptsLandlords: (LandlordWithId | ApartmentWithId)[] = [...landlords, ...apts];
 
     const options = {
@@ -568,8 +639,7 @@ app.get('/api/search', async (req, res) => {
 app.get('/api/search-results', async (req, res) => {
   try {
     const query = req.query.q as string;
-    const apts = req.app.get('apts');
-    const aptsWithType: ApartmentWithId[] = apts;
+    const aptsWithType = await loadAllAptsFromFirestore();
 
     const options = {
       keys: ['name', 'address'],
@@ -614,16 +684,10 @@ app.get('/api/search-with-query-and-filters', async (req, res) => {
     // Extract all query parameters
     const query = req.query.q as string;
     const locations = req.query.locations as string;
-    const minPrice = req.query.minPrice ? parseInt(req.query.minPrice as string, 10) : null;
-    const maxPrice = req.query.maxPrice ? parseInt(req.query.maxPrice as string, 10) : null;
-    const bedrooms = req.query.bedrooms ? parseInt(req.query.bedrooms as string, 10) : null;
-    const bathrooms = req.query.bathrooms ? parseInt(req.query.bathrooms as string, 10) : null;
     const size = req.query.size ? parseInt(req.query.size as string, 10) : null;
     const sortBy = req.query.sortBy || 'numReviews';
 
-    // Get all apartments from the application state
-    const apts = req.app.get('apts');
-    const aptsWithType: ApartmentWithId[] = apts;
+    const aptsWithType = await loadAllAptsFromFirestore();
 
     // Start with text search if query is provided
     let filteredResults: ApartmentWithId[] = [];
@@ -637,6 +701,11 @@ app.get('/api/search-with-query-and-filters', async (req, res) => {
     } else {
       // If no query, start with all apartments
       filteredResults = aptsWithType;
+    }
+
+    const requiredTagIds = parseTagIdsQuery(req.query.tagIds);
+    if (requiredTagIds.length > 0) {
+      filteredResults = filterAptsByTagIds(filteredResults, requiredTagIds);
     }
 
     // Apply location filter if provided
@@ -720,19 +789,28 @@ app.get('/api/search-with-query-and-filters', async (req, res) => {
  */
 app.get('/api/page-data/:page/:size/:sortBy?', async (req, res) => {
   const { page, size, sortBy = 'numReviews' } = req.params;
+  const requiredTagIds = parseTagIdsQuery(req.query.tagIds);
   let buildingDocs;
   let buildingData;
 
   if (page !== 'home') {
     // we only limit on size off the bat if we are not the homepage
-    buildingDocs = (await buildingsCollection.limit(Number(size)).get()).docs;
+    if (requiredTagIds.length > 0) {
+      buildingDocs = (await buildingsCollection.get()).docs;
+    } else {
+      buildingDocs = (await buildingsCollection.limit(Number(size)).get()).docs;
+    }
   } else {
     buildingDocs = (await buildingsCollection.get()).docs;
   }
 
-  const buildings: ApartmentWithId[] = buildingDocs.map(
+  let buildings: ApartmentWithId[] = buildingDocs.map(
     (doc) => ({ id: doc.id, ...doc.data() } as ApartmentWithId)
   );
+
+  if (requiredTagIds.length > 0) {
+    buildings = filterAptsByTagIds(buildings, requiredTagIds);
+  }
 
   if (page === 'home') {
     // Get enriched data first
@@ -756,7 +834,11 @@ app.get('/api/page-data/:page/:size/:sortBy?', async (req, res) => {
     // Take only the requested size
     buildingData = enrichedData.slice(0, Number(size));
   } else {
-    buildingData = await pageData(buildings);
+    let paged = buildings;
+    if (requiredTagIds.length > 0 && paged.length > Number(size)) {
+      paged = paged.slice(0, Number(size));
+    }
+    buildingData = await pageData(paged);
   }
 
   const returnData = JSON.stringify({
@@ -783,11 +865,16 @@ app.get('/api/page-data/:page/:size/:sortBy?', async (req, res) => {
  */
 app.get('/api/location/:loc', async (req, res) => {
   const { loc } = req.params;
+  const requiredTagIds = parseTagIdsQuery(req.query.tagIds);
   const buildingDocs = (await buildingsCollection.where(`area`, '==', loc.toUpperCase()).get())
     .docs;
-  const buildings: ApartmentWithId[] = buildingDocs.map(
+  let buildings: ApartmentWithId[] = buildingDocs.map(
     (doc) => ({ id: doc.id, ...doc.data() } as ApartmentWithId)
   );
+
+  if (requiredTagIds.length > 0) {
+    buildings = filterAptsByTagIds(buildings, requiredTagIds);
+  }
 
   const data = JSON.stringify(await pageData(buildings));
   return res.status(200).send(data);
@@ -829,9 +916,14 @@ app.get('/api/locations', async (req, res) => {
   }
 
   const buildingDocs = (await query.get()).docs;
-  const buildings: ApartmentWithId[] = buildingDocs.map(
+  let buildings: ApartmentWithId[] = buildingDocs.map(
     (doc) => ({ id: doc.id, ...doc.data() } as ApartmentWithId)
   );
+
+  const requiredTagIds = parseTagIdsQuery(req.query.tagIds);
+  if (requiredTagIds.length > 0) {
+    buildings = filterAptsByTagIds(buildings, requiredTagIds);
+  }
 
   const data = JSON.stringify(await pageData(buildings));
   return res.status(200).send(data);

--- a/backend/src/firebase-config/index.ts
+++ b/backend/src/firebase-config/index.ts
@@ -10,10 +10,14 @@ const hydrateServiceAccount = (): admin.ServiceAccount => {
   return { projectId, clientEmail, privateKey };
 };
 
-admin.initializeApp({
-  credential: admin.credential.cert(hydrateServiceAccount()),
-  databaseURL: process.env.REACT_APP_DATABASE_URL,
-});
+if (process.env.NODE_ENV === 'test' || process.env.FIRESTORE_EMULATOR_HOST) {
+  admin.initializeApp({ projectId: 'cuapts-68201' });
+} else {
+  admin.initializeApp({
+    credential: admin.credential.cert(hydrateServiceAccount()),
+    databaseURL: process.env.REACT_APP_DATABASE_URL,
+  });
+}
 
 const db = admin.firestore();
 const auth = admin.auth();

--- a/backend/src/server.test.ts
+++ b/backend/src/server.test.ts
@@ -38,7 +38,7 @@ describe('firestore permissions', () => {
 describe('Faqs', () => {
   // the get request should get faqs
   it('get faqs', async () => {
-    const response = await request(app).get('/');
+    const response = await request(app).get('/api/faqs');
     expect(response.status).toEqual(200);
   });
 
@@ -49,5 +49,99 @@ describe('Faqs', () => {
 
     expect(result).toBeTruthy();
     return Promise.resolve();
+  });
+});
+
+describe('Tags', () => {
+  beforeEach(async () => {
+    await clearFirestoreData({
+      projectId: 'cuapts-68201',
+    });
+
+    await db.collection('buildings').doc('apt1').set({
+      name: 'Apt 1',
+      address: '123 Test St',
+      landlordId: null,
+      numBaths: 1,
+      numBeds: 1,
+      photos: [],
+      area: 'COLLEGETOWN',
+      latitude: 42.0,
+      longitude: -76.0,
+      price: 1000,
+      distanceToCampus: 10,
+    });
+  });
+
+  it('POST /api/tags creates a new tag (returns {id,name})', async () => {
+    const response = await request(app).post('/api/tags').send({ name: 'Pet Friendly' });
+    expect(response.status).toEqual(200);
+    const body = JSON.parse(response.text);
+    expect(typeof body.id).toEqual('string');
+    expect(body.name).toEqual('Pet Friendly');
+  });
+
+  it('POST /api/tags with same name returns existing tag id (no duplicates)', async () => {
+    const r1 = await request(app).post('/api/tags').send({ name: 'Pet Friendly' });
+    const t1 = JSON.parse(r1.text);
+    const r2 = await request(app).post('/api/tags').send({ name: '  pet friendly  ' });
+    const t2 = JSON.parse(r2.text);
+    expect(t2.id).toEqual(t1.id);
+
+    const tagsSnap = await db.collection('tags').get();
+    expect(tagsSnap.docs.length).toEqual(1);
+  });
+
+  it('POST /api/apts/:id/tags/:tagId attaches tag idempotently', async () => {
+    const tagResp = await request(app).post('/api/tags').send({ name: 'Laundry' });
+    const tag = JSON.parse(tagResp.text);
+
+    const r1 = await request(app).post(`/api/apts/apt1/tags/${tag.id}`).send();
+    expect(r1.status).toEqual(200);
+    const tags1 = JSON.parse(r1.text);
+    expect(tags1).toEqual([tag.id]);
+
+    const r2 = await request(app).post(`/api/apts/apt1/tags/${tag.id}`).send();
+    expect(r2.status).toEqual(200);
+    const tags2 = JSON.parse(r2.text);
+    expect(tags2).toEqual([tag.id]);
+
+    const apt = await db.collection('buildings').doc('apt1').get();
+    expect(apt.data()?.tags).toEqual([tag.id]);
+  });
+
+  it('DELETE /api/apts/:id/tags/:tagId detaches tag idempotently', async () => {
+    const tagResp = await request(app).post('/api/tags').send({ name: 'Gym' });
+    const tag = JSON.parse(tagResp.text);
+
+    await request(app).post(`/api/apts/apt1/tags/${tag.id}`).send();
+
+    const d1 = await request(app).delete(`/api/apts/apt1/tags/${tag.id}`).send();
+    expect(d1.status).toEqual(200);
+    expect(JSON.parse(d1.text)).toEqual([]);
+
+    const d2 = await request(app).delete(`/api/apts/apt1/tags/${tag.id}`).send();
+    expect(d2.status).toEqual(200);
+    expect(JSON.parse(d2.text)).toEqual([]);
+  });
+
+  it('GET /api/apts/:id/tags returns correct tag names', async () => {
+    const t1Resp = await request(app).post('/api/tags').send({ name: 'Pet Friendly' });
+    const t2Resp = await request(app).post('/api/tags').send({ name: 'Laundry In-Unit' });
+    const t1 = JSON.parse(t1Resp.text);
+    const t2 = JSON.parse(t2Resp.text);
+
+    await request(app).post(`/api/apts/apt1/tags/${t1.id}`).send();
+    await request(app).post(`/api/apts/apt1/tags/${t2.id}`).send();
+
+    const resp = await request(app).get('/api/apts/apt1/tags');
+    expect(resp.status).toEqual(200);
+    const tags = JSON.parse(resp.text);
+    expect(tags).toEqual(
+      expect.arrayContaining([
+        { id: t1.id, name: 'Pet Friendly' },
+        { id: t2.id, name: 'Laundry In-Unit' },
+      ])
+    );
   });
 });

--- a/backend/src/server.test.ts
+++ b/backend/src/server.test.ts
@@ -125,6 +125,16 @@ describe('Tags', () => {
     expect(JSON.parse(d2.text)).toEqual([]);
   });
 
+  it('GET /api/tags lists all tags', async () => {
+    await request(app).post('/api/tags').send({ name: 'Alpha' });
+    await request(app).post('/api/tags').send({ name: 'Beta' });
+    const resp = await request(app).get('/api/tags');
+    expect(resp.status).toEqual(200);
+    const tags = JSON.parse(resp.text) as { id: string; name: string }[];
+    expect(tags.length).toEqual(2);
+    expect(tags.map((t) => t.name).sort()).toEqual(['Alpha', 'Beta']);
+  });
+
   it('GET /api/apts/:id/tags returns correct tag names', async () => {
     const t1Resp = await request(app).post('/api/tags').send({ name: 'Pet Friendly' });
     const t2Resp = await request(app).post('/api/tags').send({ name: 'Laundry In-Unit' });

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -1,1 +1,1 @@
-NODE_ENV=test jest --detectOpenHandles --forceExit
+NODE_ENV=test ./node_modules/.bin/jest --detectOpenHandles --forceExit

--- a/common/types/db-types.ts
+++ b/common/types/db-types.ts
@@ -51,6 +51,12 @@ export type Landlord = {
 export type LandlordWithId = Landlord & Id;
 export type LandlordWithLabel = LandlordWithId & { readonly label: 'LANDLORD' };
 
+export type Tag = {
+  readonly name: string;
+};
+
+export type TagWithId = Tag & Id;
+
 export type Apartment = {
   readonly name: string;
   readonly address: string; // may change to placeID for Google Maps integration
@@ -58,6 +64,7 @@ export type Apartment = {
   readonly numBaths: number | null;
   readonly numBeds: number | null;
   readonly photos: readonly string[]; // can be empty
+  readonly tags?: readonly string[];
   readonly area: 'COLLEGETOWN' | 'WEST' | 'NORTH' | 'DOWNTOWN' | 'OTHER';
   readonly latitude: number;
   readonly longitude: number;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,9 +32,9 @@
     "web-vitals": "^0.2.4"
   },
   "scripts": {
-    "start": "env-cmd -f ../.env.dev react-scripts start",
-    "start-prod": "env-cmd -f ../.env.prod react-scripts start",
-    "build": "react-scripts build",
+    "start": "env NODE_OPTIONS=--openssl-legacy-provider env-cmd -f ../.env.dev react-scripts start",
+    "start-prod": "env NODE_OPTIONS=--openssl-legacy-provider env-cmd -f ../.env.prod react-scripts start",
+    "build": "env NODE_OPTIONS=--openssl-legacy-provider react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "lint": "eslint . --ext .ts --ext .tsx",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,7 +11,7 @@ import { ThemeProvider } from '@material-ui/core';
 import { createTheme } from '@material-ui/core/styles';
 import NavBar, { NavbarButton } from './components/utils/NavBar/index';
 import NotFoundPage from './pages/NotFoundPage';
-import { ApartmentWithId } from '../../common/types/db-types';
+import { ApartmentWithId, TagWithId } from '../../common/types/db-types';
 import Footer from './components/utils/Footer';
 import ContactModal from './components/utils/Footer/ContactModal';
 import { ModalProvider } from './components/utils/Footer/ContactModalContext';
@@ -84,6 +84,8 @@ export type CardData = {
   company?: string;
   avgRating?: number;
   avgPrice?: number;
+  /** Display tags resolved from the tag collection; used on listing cards */
+  apartmentTags?: readonly TagWithId[];
 };
 
 export type LocationCardData = {

--- a/frontend/src/components/Apartment/MarkerWithAptCard.tsx
+++ b/frontend/src/components/Apartment/MarkerWithAptCard.tsx
@@ -92,6 +92,7 @@ export const MapMarkerWithCard = ({
             company={apt.company}
             user={user}
             setUser={setUser}
+            apartmentTags={apt.apartmentTags}
           />
         </div>
       )}

--- a/frontend/src/components/ApartmentCard/ApartmentImageTagBadges.tsx
+++ b/frontend/src/components/ApartmentCard/ApartmentImageTagBadges.tsx
@@ -1,0 +1,59 @@
+import React, { ReactElement } from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import { TagWithId } from '../../../../common/types/db-types';
+import { colors } from '../../colors';
+
+const useStyles = makeStyles({
+  root: {
+    position: 'absolute',
+    top: 10,
+    left: 10,
+    right: 48,
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: 6,
+    zIndex: 1,
+    pointerEvents: 'none',
+  },
+  chip: {
+    display: 'inline-block',
+    boxSizing: 'border-box',
+    color: colors.black,
+    backgroundColor: colors.white,
+    fontSize: 12,
+    fontWeight: 700,
+    lineHeight: 1.25,
+    letterSpacing: '0.01em',
+    padding: '8px 14px',
+    minHeight: 32,
+    borderRadius: 9999,
+    boxShadow: '0 1px 3px rgba(0, 0, 0, 0.12)',
+  },
+});
+
+const MAX = 2;
+
+type Props = {
+  tags?: readonly TagWithId[] | undefined;
+};
+
+const ApartmentImageTagBadges = ({ tags }: Props): ReactElement | null => {
+  const classes = useStyles();
+  if (!tags || tags.length === 0) {
+    return null;
+  }
+  const shown = tags.slice(0, MAX);
+  const extra = tags.length - shown.length;
+  return (
+    <div className={classes.root} aria-label="apartment tags">
+      {shown.map((t) => (
+        <span key={t.id} className={classes.chip}>
+          {t.name}
+        </span>
+      ))}
+      {extra > 0 && <span className={classes.chip}>+{extra}</span>}
+    </div>
+  );
+};
+
+export default ApartmentImageTagBadges;

--- a/frontend/src/components/ApartmentCard/HomePageApartmentCards.tsx
+++ b/frontend/src/components/ApartmentCard/HomePageApartmentCards.tsx
@@ -243,7 +243,7 @@ const ApartmentCards = ({
       <div className={classes.cardsContainer} ref={containerRef}>
         {data &&
           sortApartments(data, sortMethod, orderLowToHigh).map(
-            ({ buildingData, numReviews, company, avgRating }, index) => {
+            ({ buildingData, numReviews, company, avgRating, apartmentTags }, index) => {
               const { id } = buildingData;
               return (
                 <div key={id}>
@@ -263,6 +263,7 @@ const ApartmentCards = ({
                         company={company}
                         user={user}
                         setUser={setUser}
+                        apartmentTags={apartmentTags}
                       />
                     ) : (
                       <LargeApartmentCard
@@ -273,6 +274,7 @@ const ApartmentCards = ({
                         company={company}
                         user={user}
                         setUser={setUser}
+                        apartmentTags={apartmentTags}
                       />
                     )}
                   </Link>

--- a/frontend/src/components/ApartmentCard/LargeApartmentCard.tsx
+++ b/frontend/src/components/ApartmentCard/LargeApartmentCard.tsx
@@ -16,7 +16,13 @@ import bedIcon from '../../assets/apartment-card-bedroom-icon.svg';
 import moneyIcon from '../../assets/apartment-card-money-icon.svg';
 import axios from 'axios';
 import { createAuthHeaders, getUser } from '../../utils/firebase';
-import { ApartmentWithId, DetailedRating, ReviewWithId } from '../../../../common/types/db-types';
+import {
+  ApartmentWithId,
+  DetailedRating,
+  ReviewWithId,
+  TagWithId,
+} from '../../../../common/types/db-types';
+import ApartmentImageTagBadges from './ApartmentImageTagBadges';
 import { colors } from '../../colors';
 import HeartRating from '../utils/HeartRating';
 import ReviewHeader from '../Review/ReviewHeader';
@@ -29,6 +35,7 @@ type Props = {
   company?: string;
   user: firebase.User | null;
   setUser: React.Dispatch<React.SetStateAction<firebase.User | null>>;
+  apartmentTags?: readonly TagWithId[];
 };
 
 const useStyles = makeStyles({
@@ -199,13 +206,14 @@ const useStyles = makeStyles({
  * @param {React.Dispatch<React.SetStateAction<firebase.User | null>>} props.setUser - Function to update the user state.
  * @returns {ReactElement} NewApartmentCard component.
  */
-const NewApartmentCard = ({
+const LargeApartmentCard = ({
   buildingData,
   numReviews,
   avgRating,
   company,
   user,
   setUser,
+  apartmentTags,
 }: Props): ReactElement => {
   const { id, name, photos, address, area } = buildingData;
   const saved = savedIcon;
@@ -314,6 +322,7 @@ const NewApartmentCard = ({
     >
       <div className={cardContainer}>
         <CardMedia className={apartmentImageContainer}>
+          <ApartmentImageTagBadges tags={apartmentTags} />
           <img src={img} alt="apartment" className={apartmentImage} />
         </CardMedia>
         <div className={apartmentInfo}>
@@ -355,4 +364,4 @@ const NewApartmentCard = ({
   );
 };
 
-export default NewApartmentCard;
+export default LargeApartmentCard;

--- a/frontend/src/components/ApartmentCard/NewApartmentCard.tsx
+++ b/frontend/src/components/ApartmentCard/NewApartmentCard.tsx
@@ -15,7 +15,8 @@ import bedIcon from '../../assets/apartment-card-bedroom-icon.svg';
 import moneyIcon from '../../assets/apartment-card-money-icon.svg';
 import axios from 'axios';
 import { createAuthHeaders, getUser } from '../../utils/firebase';
-import { ApartmentWithId } from '../../../../common/types/db-types';
+import { ApartmentWithId, TagWithId } from '../../../../common/types/db-types';
+import ApartmentImageTagBadges from './ApartmentImageTagBadges';
 import FavoriteIcon from '@material-ui/icons/Favorite';
 import { colors } from '../../colors';
 
@@ -26,6 +27,7 @@ type Props = {
   company?: string;
   user: firebase.User | null;
   setUser: React.Dispatch<React.SetStateAction<firebase.User | null>>;
+  apartmentTags?: readonly TagWithId[];
 };
 
 const useStyles = makeStyles({
@@ -72,6 +74,7 @@ const useStyles = makeStyles({
     position: 'absolute',
     top: '12px',
     right: '12px',
+    zIndex: 2,
     objectPosition: 'center',
     objectFit: 'cover',
     transition: 'scale 0.2s',
@@ -192,6 +195,7 @@ const NewApartmentCard = ({
   company,
   user,
   setUser,
+  apartmentTags,
 }: Props): ReactElement => {
   const { id, name, photos, address, numBeds = 0, distanceToCampus = 0 } = buildingData;
   const saved = savedIcon;
@@ -276,6 +280,7 @@ const NewApartmentCard = ({
     >
       <div className={cardContainer}>
         <CardMedia className={apartmentImageContainer}>
+          <ApartmentImageTagBadges tags={apartmentTags} />
           <IconButton
             disableRipple
             onClick={handleSaveToggle}

--- a/frontend/src/components/ApartmentCard/SearchResultsPageApartmentCards.tsx
+++ b/frontend/src/components/ApartmentCard/SearchResultsPageApartmentCards.tsx
@@ -124,7 +124,7 @@ const ApartmentCards = ({
       <div className={cardsContainer}>
         {data &&
           sortApartments(data, sortMethod, orderLowToHigh).map(
-            ({ buildingData, numReviews, company, avgRating }, index) => {
+            ({ buildingData, numReviews, company, avgRating, apartmentTags }, index) => {
               const { id } = buildingData;
               return (
                 <>
@@ -144,6 +144,7 @@ const ApartmentCards = ({
                         company={company}
                         user={user}
                         setUser={setUser}
+                        apartmentTags={apartmentTags}
                       />
                     </Link>
                   </div>

--- a/frontend/src/components/Search/Autocomplete.tsx
+++ b/frontend/src/components/Search/Autocomplete.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useEffect, useState, useRef } from 'react';
+import React, { ReactElement, useCallback, useEffect, useState, useRef } from 'react';
 import { useLocation } from 'react-router-dom';
 import {
   CircularProgress,
@@ -12,7 +12,7 @@ import {
   IconButton,
 } from '@material-ui/core';
 import { get } from '../../utils/call';
-import { LandlordOrApartmentWithLabel } from '../../../../common/types/db-types';
+import { LandlordOrApartmentWithLabel, TagWithId } from '../../../../common/types/db-types';
 import SearchIcon from '../../assets/search-icon.svg';
 import { makeStyles } from '@material-ui/core/styles';
 import { colors } from '../../colors';
@@ -21,21 +21,12 @@ import { Link as RouterLink } from 'react-router-dom';
 import searchPropertyIcon from '../../assets/search-property.svg';
 import searchLandlordIcon from '../../assets/search-landlord.svg';
 import filterIcon from '../../assets/filter.svg';
-import FilterSection, { FilterState } from './FilterSection';
+import FilterSection, { defaultFilters, FilterState } from './FilterSection';
 import FilterDropDown from './FilterDropDown';
+import TagSearchSection from './TagSearchSection';
 
 type Props = {
   drawerOpen: boolean;
-};
-
-const defaultFilters: FilterState = {
-  locations: [],
-  minPrice: '',
-  maxPrice: '',
-  bedrooms: 0,
-  bathrooms: 0,
-  initialSortBy: 'avgRating',
-  initialSortLowToHigh: false,
 };
 
 /**
@@ -60,18 +51,25 @@ const Autocomplete = ({ drawerOpen }: Props): ReactElement => {
   const location = useLocation();
   const isHome = location.pathname === '/';
   const isSearchResults = location.pathname.startsWith('/search');
+  const isLocationPage = location.pathname.startsWith('/location/');
 
   const useStyles = makeStyles((theme) => ({
     menuList: {
       position: 'absolute',
+      top: '100%',
+      left: 0,
+      right: 0,
+      zIndex: 1300,
+      width: '100%',
       backgroundColor: colors.white,
-      maxHeight: 200,
+      maxHeight: 420,
       overflow: 'auto',
       boxShadow: '0px 4px 8px -1px rgba(0, 0, 0, 0.25)',
       borderRadius: '8px',
       padding: 0,
       boxSizing: 'border-box',
       border: '2px solid white',
+      marginTop: 4,
     },
     menuItem: {
       borderBottom: '1px solid #E5E5E5',
@@ -187,6 +185,8 @@ const Autocomplete = ({ drawerOpen }: Props): ReactElement => {
   const [openMenu, setOpenMenu] = useState(false);
   const [options, setOptions] = useState<LandlordOrApartmentWithLabel[]>([]);
   const [selected, setSelected] = useState<LandlordOrApartmentWithLabel | null>(null);
+  const [allTags, setAllTags] = useState<TagWithId[]>([]);
+  const [tagsLoading, setTagsLoading] = useState(true);
   const history = useHistory();
 
   useEffect(() => {
@@ -258,8 +258,32 @@ const Autocomplete = ({ drawerOpen }: Props): ReactElement => {
     }
   };
 
-  const handleFilterChange = (newFilters: FilterState) => {
-    setFilters(newFilters);
+  const handleFilterChange = useCallback(
+    (newFilters: FilterState) => {
+      setFilters(newFilters);
+      if (!isHome && !isLocationPage && !isSearchResults) {
+        return;
+      }
+      const qParam = isSearchResults
+        ? (query.trim() || new URLSearchParams(location.search).get('q') || '').trim()
+        : query.trim();
+      const q = qParam ? `q=${encodeURIComponent(qParam)}` : '';
+      const f =
+        JSON.stringify(newFilters) !== JSON.stringify(defaultFilters)
+          ? `filters=${encodeURIComponent(JSON.stringify(newFilters))}`
+          : '';
+      const parts = [q, f].filter(Boolean);
+      const pathname = isSearchResults ? '/search' : isHome ? '/' : location.pathname;
+      history.replace({
+        pathname,
+        search: parts.length > 0 ? `?${parts.join('&')}` : '',
+      });
+    },
+    [history, isHome, isLocationPage, isSearchResults, location.pathname, location.search, query]
+  );
+
+  const handleSearchFocus = () => {
+    setOpenMenu(true);
   };
 
   /**
@@ -273,79 +297,94 @@ const Autocomplete = ({ drawerOpen }: Props): ReactElement => {
    * @returns {ReactElement} A dropdown menu component containing search results
    */
   const Menu = () => {
+    if (!openMenu) {
+      return null;
+    }
     return (
-      <div>
-        <ClickAwayListener
-          onClickAway={() => {
-            setOpenMenu(false);
-          }}
-        >
-          <div>
-            {openMenu ? (
-              <MenuList
-                style={{ width: `${inputRef.current?.offsetWidth}px`, zIndex: 1 }}
-                className={menuList}
-                autoFocusItem={focus}
-                onKeyDown={handleListKeyDown}
-              >
-                {options.length === 0 ? (
-                  <MenuItem disabled>No search results.</MenuItem>
-                ) : (
-                  options.map(({ id, name, address, label }, index) => {
-                    return (
-                      <Link
-                        key={index}
-                        {...{
-                          to: `/${label.toLowerCase()}/${id}`,
-                          style: { textDecoration: 'none' },
-                          component: RouterLink,
-                        }}
-                      >
-                        <MenuItem
-                          button={true}
-                          key={index}
-                          onClick={() => setOpenMenu(false)}
-                          className={menuItem}
-                          style={index === options.length - 1 ? { borderBottom: 'none' } : {}}
-                        >
-                          <Grid container spacing={2} alignItems="center">
-                            <Grid item className={searchMenuLabelIcon}>
-                              <img
-                                src={label === 'LANDLORD' ? searchLandlordIcon : searchPropertyIcon}
-                                alt="search icon"
-                              />
-                            </Grid>
-                            <Grid item xs style={{ minWidth: 0 }}>
-                              <Typography className={buildingText}>{name}</Typography>
-                              <Typography className={subText}>
-                                {address !== name && address}
-                              </Typography>
-                              <Typography className={subText}>
-                                {label === 'LANDLORD' && 'Landlord'}
-                              </Typography>
-                            </Grid>
-                          </Grid>
-                        </MenuItem>
-                      </Link>
-                    );
-                  })
-                )}
-              </MenuList>
-            ) : null}
-          </div>
-        </ClickAwayListener>
-      </div>
+      <MenuList className={menuList} autoFocusItem={focus} onKeyDown={handleListKeyDown}>
+        <TagSearchSection
+          allTags={allTags}
+          tagsLoading={tagsLoading}
+          filters={filters}
+          onChange={handleFilterChange}
+        />
+        {query.trim() !== '' &&
+          (options.length === 0 ? (
+            <MenuItem disabled>No search results.</MenuItem>
+          ) : (
+            options.map(({ id, name, address, label }, index) => {
+              return (
+                <Link
+                  key={index}
+                  {...{
+                    to: `/${label.toLowerCase()}/${id}`,
+                    style: { textDecoration: 'none' },
+                    component: RouterLink,
+                  }}
+                >
+                  <MenuItem
+                    button={true}
+                    key={index}
+                    onClick={() => setOpenMenu(false)}
+                    className={menuItem}
+                    style={index === options.length - 1 ? { borderBottom: 'none' } : {}}
+                  >
+                    <Grid container spacing={2} alignItems="center">
+                      <Grid item className={searchMenuLabelIcon}>
+                        <img
+                          src={label === 'LANDLORD' ? searchLandlordIcon : searchPropertyIcon}
+                          alt="search icon"
+                        />
+                      </Grid>
+                      <Grid item xs style={{ minWidth: 0 }}>
+                        <Typography className={buildingText}>{name}</Typography>
+                        <Typography className={subText}>{address !== name && address}</Typography>
+                        <Typography className={subText}>
+                          {label === 'LANDLORD' && 'Landlord'}
+                        </Typography>
+                      </Grid>
+                    </Grid>
+                  </MenuItem>
+                </Link>
+              );
+            })
+          ))}
+      </MenuList>
     );
   };
   useEffect(() => {
-    if (query === '') {
+    if (selected !== null) {
       setOpenMenu(false);
-    } else if (selected === null) {
+    } else if (query !== '') {
       setOpenMenu(true);
-    } else {
-      setOpenMenu(false);
     }
   }, [query, selected]);
+
+  useEffect(() => {
+    setTagsLoading(true);
+    get<TagWithId[]>(`/api/tags`, {
+      callback: (data) => {
+        setAllTags(data);
+        setTagsLoading(false);
+      },
+      errorHandler: () => {
+        setAllTags([]);
+        setTagsLoading(false);
+      },
+    });
+  }, []);
+
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    const raw = params.get('filters');
+    if (raw) {
+      try {
+        setFilters({ ...defaultFilters, ...JSON.parse(decodeURIComponent(raw)) });
+      } catch {
+        // ignore bad filter blobs in URL
+      }
+    }
+  }, [location.search]);
 
   useEffect(() => {
     const handleResize = () => {
@@ -453,8 +492,8 @@ const Autocomplete = ({ drawerOpen }: Props): ReactElement => {
         width: '100%',
       }}
     >
-      {/* Row 1: Search bar */}
-      <div style={{ width: '100%' }}>
+      {/* Row 1: Search bar + tag / address menu */}
+      <div style={{ position: 'relative', width: '100%' }}>
         <TextField
           fullWidth
           ref={inputRef}
@@ -466,6 +505,7 @@ const Autocomplete = ({ drawerOpen }: Props): ReactElement => {
             borderRadius: openFilter ? '10px 10px 0px 0px' : '10px',
             width: '100%',
           }}
+          onFocus={handleSearchFocus}
           onKeyDown={textFieldHandleListKeyDown}
           onChange={(event) => {
             const value = event.target.value;
@@ -475,6 +515,7 @@ const Autocomplete = ({ drawerOpen }: Props): ReactElement => {
           }}
           InputProps={getInputProps()}
         />
+        <Menu />
       </div>
       {/* Row 2: Three dropdowns */}
       <div
@@ -524,26 +565,35 @@ const Autocomplete = ({ drawerOpen }: Props): ReactElement => {
                 width: !isSearchResults && isMobile ? '130%' : '100%',
               }}
             >
-              <TextField
-                fullWidth
-                ref={inputRef}
-                value={query}
-                placeholder={placeholderText}
-                className={text}
-                variant="outlined"
+              <div
                 style={{
-                  borderRadius: openFilter ? '10px 10px 0px 0px' : '10px',
+                  position: 'relative',
                   width: isSearchResults ? '58%' : '100%',
                 }}
-                onKeyDown={textFieldHandleListKeyDown}
-                onChange={(event) => {
-                  const value = event.target.value;
-                  if (value !== '' || value !== null) {
-                    handleOnChange(value);
-                  }
-                }}
-                InputProps={getInputProps()}
-              />
+              >
+                <TextField
+                  fullWidth
+                  ref={inputRef}
+                  value={query}
+                  placeholder={placeholderText}
+                  className={text}
+                  variant="outlined"
+                  style={{
+                    borderRadius: openFilter ? '10px 10px 0px 0px' : '10px',
+                    width: '100%',
+                  }}
+                  onFocus={handleSearchFocus}
+                  onKeyDown={textFieldHandleListKeyDown}
+                  onChange={(event) => {
+                    const value = event.target.value;
+                    if (value !== '' || value !== null) {
+                      handleOnChange(value);
+                    }
+                  }}
+                  InputProps={getInputProps()}
+                />
+                <Menu />
+              </div>
               {isSearchResults && (
                 <div className={filterRow}>
                   <FilterDropDown
@@ -571,7 +621,6 @@ const Autocomplete = ({ drawerOpen }: Props): ReactElement => {
               )}
             </div>
           )}
-          <Menu />
           <FilterSection
             filters={filters}
             onChange={handleFilterChange}

--- a/frontend/src/components/Search/FilterSection.tsx
+++ b/frontend/src/components/Search/FilterSection.tsx
@@ -17,7 +17,7 @@ import { CardData } from '../../App';
 const useStyles = makeStyles({
   filterContainer: {
     position: 'absolute',
-    zIndex: 1,
+    zIndex: 10,
     minWidth: '100%',
     backgroundColor: 'white',
     borderRadius: '0px 0px 10px 10px',
@@ -238,6 +238,7 @@ export type FilterState = {
   maxPrice: string;
   bedrooms: number;
   bathrooms: number;
+  tagIds: string[];
   initialSortBy: keyof CardData | keyof ApartmentWithId | 'originalOrder';
   initialSortLowToHigh: boolean;
 };
@@ -248,6 +249,7 @@ export const defaultFilters: FilterState = {
   maxPrice: '',
   bedrooms: 0,
   bathrooms: 0,
+  tagIds: [],
   initialSortBy: 'avgRating',
   initialSortLowToHigh: false,
 };

--- a/frontend/src/components/Search/TagSearchSection.tsx
+++ b/frontend/src/components/Search/TagSearchSection.tsx
@@ -1,0 +1,164 @@
+import React, { ReactElement } from 'react';
+import { makeStyles, Typography, IconButton } from '@material-ui/core';
+import CloseIcon from '@material-ui/icons/Close';
+import { TagWithId } from '../../../../common/types/db-types';
+import { colors } from '../../colors';
+import { FilterState } from './FilterSection';
+
+const useStyles = makeStyles({
+  section: {
+    padding: '12px 16px 10px',
+    borderBottom: '1px solid #E5E5E5',
+  },
+  label: {
+    color: 'rgba(0, 0, 0, 0.5)',
+    fontSize: 12,
+    fontWeight: 600,
+    marginBottom: 8,
+  },
+  helper: {
+    color: 'rgba(0, 0, 0, 0.45)',
+    fontSize: 12,
+    fontWeight: 400,
+    marginBottom: 8,
+    lineHeight: 1.35,
+  },
+  row: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: 8,
+    alignItems: 'center',
+  },
+  chip: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    boxSizing: 'border-box',
+    borderRadius: 9999,
+    padding: '6px 8px 6px 12px',
+    minHeight: 28,
+    backgroundColor: colors.red1,
+    color: colors.white,
+    fontSize: 12,
+    fontWeight: 500,
+    lineHeight: 1.2,
+    maxWidth: '100%',
+  },
+  chipInactive: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    boxSizing: 'border-box',
+    borderRadius: 9999,
+    minHeight: 28,
+    padding: '6px 14px',
+    backgroundColor: 'rgba(185, 70, 48, 0.12)',
+    color: colors.red1,
+    cursor: 'pointer',
+    border: 'none',
+    font: 'inherit',
+    fontSize: 12,
+    fontWeight: 500,
+    lineHeight: 1.2,
+    whiteSpace: 'nowrap',
+    WebkitAppearance: 'none' as const,
+    transition: 'background-color 0.15s ease',
+    '&:hover': {
+      backgroundColor: 'rgba(185, 70, 48, 0.2)',
+    },
+    '&:focus': {
+      outline: 'none',
+    },
+  },
+  name: {
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    maxWidth: 160,
+  },
+  clearBtn: {
+    padding: 2,
+    color: colors.white,
+    marginLeft: 2,
+    '&:hover': {
+      backgroundColor: 'rgba(255,255,255,0.2)',
+    },
+  },
+});
+
+type Props = {
+  allTags: TagWithId[];
+  tagsLoading?: boolean;
+  filters: FilterState;
+  onChange: (f: FilterState) => void;
+};
+
+const TagSearchSection = ({
+  allTags,
+  tagsLoading = false,
+  filters,
+  onChange,
+}: Props): ReactElement => {
+  const c = useStyles();
+
+  const selected = new Set(filters.tagIds);
+  const toggle = (id: string) => {
+    const next = new Set(filters.tagIds);
+    if (next.has(id)) {
+      next.delete(id);
+    } else {
+      next.add(id);
+    }
+    onChange({ ...filters, tagIds: Array.from(next) });
+  };
+
+  return (
+    <div className={c.section} onMouseDown={(e) => e.preventDefault()} data-testid="search-by-tags">
+      <Typography className={c.label} component="div">
+        Search by tags
+      </Typography>
+      {tagsLoading && (
+        <Typography className={c.helper} component="div">
+          Loading tags…
+        </Typography>
+      )}
+      {!tagsLoading && allTags.length === 0 && (
+        <Typography className={c.helper} component="div">
+          No tags in the directory yet. Once tags exist, you can filter search results with them.
+        </Typography>
+      )}
+      <div className={c.row}>
+        {!tagsLoading &&
+          allTags.map((t) => {
+            const isOn = selected.has(t.id);
+            if (isOn) {
+              return (
+                <span key={t.id} className={c.chip} title={t.name}>
+                  <span className={c.name}>{t.name}</span>
+                  <IconButton
+                    size="small"
+                    className={c.clearBtn}
+                    onClick={() => toggle(t.id)}
+                    aria-label={`Remove ${t.name}`}
+                  >
+                    <CloseIcon style={{ fontSize: 16 }} />
+                  </IconButton>
+                </span>
+              );
+            }
+            return (
+              <button
+                key={t.id}
+                type="button"
+                className={c.chipInactive}
+                onClick={() => toggle(t.id)}
+              >
+                {t.name}
+              </button>
+            );
+          })}
+      </div>
+    </div>
+  );
+};
+
+export default TagSearchSection;

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -13,6 +13,7 @@ import { useSaveScrollPosition } from '../utils/saveScrollPosition';
 import { useLocation } from 'react-router-dom';
 import HomePageApartmentCards from '../components/ApartmentCard/HomePageApartmentCards';
 import logo from '../assets/3d-logo.svg';
+import { tagIdsSearchSuffix } from '../utils/tagQueryFromUrl';
 
 type returnData = {
   buildingData: CardData[];
@@ -65,16 +66,17 @@ const HomePage = ({ user, setUser }: Props): ReactElement => {
   useTitle('Home');
 
   useEffect(() => {
-    get<returnData>(`/api/page-data/home/${loadingLength}/distanceToCampus`, {
+    const t = tagIdsSearchSuffix(path.search);
+    get<returnData>(`/api/page-data/home/${loadingLength}/distanceToCampus${t}`, {
       callback: setCloseToCampusData,
     });
-    get<returnData>(`/api/page-data/home/${loadingLength}/numReviews`, {
+    get<returnData>(`/api/page-data/home/${loadingLength}/numReviews${t}`, {
       callback: setMostReviewedData,
     });
-    get<returnData>(`/api/page-data/home/${loadingLength}/avgRating`, {
+    get<returnData>(`/api/page-data/home/${loadingLength}/avgRating${t}`, {
       callback: setMostLovedData,
     });
-  }, []);
+  }, [path.search]);
 
   useEffect(() => {
     const handleResize = () => setIsMobile(window.innerWidth <= 600);
@@ -93,6 +95,11 @@ const HomePage = ({ user, setUser }: Props): ReactElement => {
       marginTop: '93px',
       marginBottom: '100px',
       position: 'relative',
+      zIndex: 20,
+    },
+    listingsBelowSearch: {
+      position: 'relative',
+      zIndex: 0,
     },
     jumboText: {
       fontSize: isMobile ? '26px' : '48px',
@@ -122,7 +129,8 @@ const HomePage = ({ user, setUser }: Props): ReactElement => {
     },
   });
 
-  const { header, jumboText, jumboSub, logoContainer, logoImage } = useStyles();
+  const { header, jumboText, jumboSub, logoContainer, logoImage, listingsBelowSearch } =
+    useStyles();
 
   return (
     <Container maxWidth="xl">
@@ -141,7 +149,7 @@ const HomePage = ({ user, setUser }: Props): ReactElement => {
         </Box>
       </Box>
 
-      <Box style={{ marginLeft: '4.5vw', marginRight: '4.5vw' }}>
+      <Box className={listingsBelowSearch} style={{ marginLeft: '4.5vw', marginRight: '4.5vw' }}>
         <>
           <Box mb={8}>
             <HomePageApartmentCards

--- a/frontend/src/pages/LocationPage.tsx
+++ b/frontend/src/pages/LocationPage.tsx
@@ -10,6 +10,7 @@ import { CardData } from '../App';
 import { get } from '../utils/call';
 import ApartmentCards from '../components/ApartmentCard/ApartmentCards';
 import { useSaveScrollPosition } from '../utils/saveScrollPosition';
+import { tagIdsSearchSuffix } from '../utils/tagQueryFromUrl';
 
 interface Images {
   [location: string]: string;
@@ -65,7 +66,11 @@ const LocationPage = ({ user, setUser }: Props): ReactElement => {
   const path = useLocation();
   const [pathName] = useState(path.pathname);
   const location = path.pathname.substring(path.pathname.lastIndexOf('/') + 1);
-  const locAPI = `/api/location/${location}/`;
+  const locTagSuffix = tagIdsSearchSuffix(path.search);
+  const locAPI =
+    locTagSuffix.length > 0
+      ? `/api/location/${location}/` + locTagSuffix
+      : `/api/location/${location}/`;
   const locToImg: Images = {
     Collegetown: CollegetownImg,
     West: WestImg,

--- a/frontend/src/pages/SearchResultsPage.tsx
+++ b/frontend/src/pages/SearchResultsPage.tsx
@@ -7,7 +7,7 @@ import { CardData } from '../App';
 import ApartmentCards from '../components/ApartmentCard/ApartmentCards';
 import { useTitle } from '../utils';
 import { useSaveScrollPosition } from '../utils/saveScrollPosition';
-import { defaultFilters } from '../components/Search/FilterSection';
+import { defaultFilters, FilterState } from '../components/Search/FilterSection';
 import Autocomplete from '../components/Search/Autocomplete';
 import SearchResultsPageApartmentCards from '../components/ApartmentCard/SearchResultsPageApartmentCards';
 import SearchResultsMap from '../components/Search/SearchResultsMap';
@@ -16,6 +16,8 @@ import { ApartmentWithId } from '../../../common/types/db-types';
 
 const useStyles = makeStyles({
   header: {
+    position: 'relative',
+    zIndex: 20,
     marginLeft: '0.5vw',
     marginRight: '0.5vw',
     display: 'flex',
@@ -25,6 +27,8 @@ const useStyles = makeStyles({
     marginBottom: '24px',
   },
   mainContent: {
+    position: 'relative',
+    zIndex: 0,
     display: 'flex',
     flexDirection: 'row',
     gap: '12px',
@@ -85,11 +89,18 @@ const SearchResultsPage = ({ user, setUser }: Props): ReactElement => {
   const { query, filters } = useMemo(() => {
     window.scrollTo(0, 0);
     const params = new URLSearchParams(path.search);
+    const raw = params.get('filters');
+    let parsed: Partial<FilterState> = {};
+    if (raw) {
+      try {
+        parsed = JSON.parse(decodeURIComponent(raw));
+      } catch {
+        parsed = {};
+      }
+    }
     return {
       query: params.get('q') || '',
-      filters: params.get('filters')
-        ? JSON.parse(decodeURIComponent(params.get('filters') || '{}'))
-        : defaultFilters,
+      filters: { ...defaultFilters, ...parsed },
     };
   }, [path.search]);
 
@@ -125,6 +136,10 @@ const SearchResultsPage = ({ user, setUser }: Props): ReactElement => {
 
     if (filters.bathrooms > 0) {
       params.append('bathrooms', filters.bathrooms.toString());
+    }
+
+    if (filters.tagIds && filters.tagIds.length > 0) {
+      params.append('tagIds', filters.tagIds.join(','));
     }
 
     // Add sortBy parameter if it's not 'originalOrder'

--- a/frontend/src/utils/tagQueryFromUrl.ts
+++ b/frontend/src/utils/tagQueryFromUrl.ts
@@ -1,0 +1,32 @@
+import type { FilterState } from '../components/Search/FilterSection';
+
+export function tagIdsQueryFromSearch(search: string): string {
+  if (!search) {
+    return '';
+  }
+  const p = new URLSearchParams(search.startsWith('?') ? search : `?${search}`);
+  const raw = p.get('filters');
+  if (!raw) {
+    return '';
+  }
+  let parsed: Partial<FilterState> = {};
+  try {
+    parsed = JSON.parse(decodeURIComponent(raw)) as Partial<FilterState>;
+  } catch {
+    try {
+      parsed = JSON.parse(raw) as Partial<FilterState>;
+    } catch {
+      return '';
+    }
+  }
+  const tagIds = parsed.tagIds;
+  if (Array.isArray(tagIds) && tagIds.length > 0) {
+    return `tagIds=${encodeURIComponent(tagIds.join(','))}`;
+  }
+  return '';
+}
+
+export function tagIdsSearchSuffix(search: string): string {
+  const q = tagIdsQueryFromSearch(search);
+  return q ? `?${q}` : '';
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7862,7 +7862,7 @@ jest-circus@26.6.0:
     stack-utils "^2.0.2"
     throat "^5.0.0"
 
-jest-cli@^26.6.0:
+jest-cli@^26.6.0, jest-cli@^26.6.3:
   version "26.6.3"
   resolved "https://registry.npmjs.org/jest-cli/-/jest-cli-26.6.3.tgz"
   integrity sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==
@@ -8284,6 +8284,15 @@ jest@26.6.0:
     "@jest/core" "^26.6.0"
     import-local "^3.0.2"
     jest-cli "^26.6.0"
+
+jest@^26.6.0:
+  version "26.6.3"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-26.6.3.tgz#40e8fdbe48f00dfa1f0ce8121ca74b88ac9148ef"
+  integrity sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==
+  dependencies:
+    "@jest/core" "^26.6.3"
+    import-local "^3.0.2"
+    jest-cli "^26.6.3"
 
 jose@^2.0.5:
   version "2.0.5"


### PR DESCRIPTION
### Summary

Adds property tags end-to-end: create/list tags, attach them to buildings, show them in search, and show pills on listing photos so users can filter by tag from the home page, full-text search, and area pages.

### Features

Search: “Search by tags” in the autocomplete panel; selected tags are sent with search and kept in the URL filters param on home, /search, and /location/:area.

Listings: apartmentTags on card/map data; ApartmentImageTagBadges on card images (up to 2 + overflow).

Backend: GET /api/tags; existing POST/DELETE on building tags; GET /api/apts/:id/tags; tagIds query on GET /api/page-data/..., GET /api/location/:loc, GET /api/locations, and GET /api/search-with-query-and-filters.

Search and autocomplete use live Firestore data for buildings/landlords so tag assignments are not stale vs POST /api/set-data cache.

backend/scripts/seed_example_tags.ts (run via yarn seed_example_tags in backend/) seeds three example tags and assigns them to a small subset of buildings (heuristics: distance, price, review count).

Frontend build: NODE_OPTIONS=--openssl-legacy-provider in scripts where needed for local builds on newer Node.

Tests: server.test.ts extended for tag APIs.

### Not in scope / follow-ups

(Optional) Admin UI to create tags beyond API/seed (if product wants that later)