### PR TITLE
Apartments page redesign (backend and frontend)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,20 @@ on its own, run `yarn frontend-dev` or `yarn backend-dev`.
 
 ## Contributors
 
+### 2025-2026
+
+- **Ella Krechmer** - Product Manager Advisor
+- **Jaeyoung Lee** - Product Manager
+- **Celline Lee** -  Product Manager
+- **Helen Song** - Product Marketing Manager
+- **Casper Liao** - Technical Product Manager
+- **Xintog Lee**- Designer
+- **Erica Lee** - Designer
+- **May Wu** - Designer
+- **Parsa Tehranipoor** - Developer
+- **Lauren Pothuru** - Developer
+- **Natan Kramskiy** - Developer
+
 ### 2024-2025
 
 - **Ella Krechmer** - Product Manager

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ on its own, run `yarn frontend-dev` or `yarn backend-dev`.
 - **Celline Lee** - Product Manager
 - **Helen Song** - Product Marketing Manager
 - **Casper Liao** - Technical Product Manager
-- **Xintog Lee** - Designer
+- **Xintong Lin** - Designer
 - **Erica Lee** - Designer
 - **May Wu** - Designer
 - **Parsa Tehranipoor** - Developer

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ on its own, run `yarn frontend-dev` or `yarn backend-dev`.
 
 - **Ella Krechmer** - Product Manager Advisor
 - **Jaeyoung Lee** - Product Manager
-- **Celline Lee** -  Product Manager
+- **Celline Lee** - Product Manager
 - **Helen Song** - Product Marketing Manager
 - **Casper Liao** - Technical Product Manager
-- **Xintog Lee**- Designer
+- **Xintog Lee** - Designer
 - **Erica Lee** - Designer
 - **May Wu** - Designer
 - **Parsa Tehranipoor** - Developer

--- a/backend/scripts/add_buildings.ts
+++ b/backend/scripts/add_buildings.ts
@@ -13,6 +13,7 @@ type BuildingData = {
   latitude?: number;
   longitude?: number;
   distanceToCampus?: number;
+  description?: string;
 };
 
 const getAreaType = (areaName: string): 'COLLEGETOWN' | 'WEST' | 'NORTH' | 'DOWNTOWN' | 'OTHER' => {
@@ -38,6 +39,7 @@ const formatBuilding = ({
   area,
   latitude = 0,
   longitude = 0,
+  description,
 }: BuildingData): ApartmentWithId => ({
   id: id.toString(),
   name,
@@ -49,6 +51,9 @@ const formatBuilding = ({
   latitude,
   longitude,
   distanceToCampus: 0,
+  description: description ?? '',
+  amenities: [],
+  floorplans: [],
 });
 
 const makeBuilding = async (apartmentWithId: ApartmentWithId) => {

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -34,6 +34,7 @@ import { Faq } from './firebase-config/types';
 import authenticate from './auth';
 import authenticateAdmin, { isAdminEmail } from './authAdmin';
 import { admins } from '../../frontend/src/constants/HomeConsts';
+import { BUS_STOPS, getTravelTimes, findClosestStop } from './travel-times-utils';
 
 // Imports for email sending
 
@@ -450,6 +451,82 @@ app.get('/api/review/:idType/:id/:status', async (req, res) => {
   res.status(200).send(JSON.stringify(reviews));
 });
 
+/**
+ * apartment-rating-summary – Aggregates approved review ratings for an apartment.
+ *
+ * @remarks
+ * Averages the overall rating and each detailed category across every approved
+ * review for the apartment. An apartment with no approved reviews returns a
+ * summary of all zeroes with a `reviewCount` of 0, which callers use to render
+ * an "N/A" state. Averages are clamped to the valid 0–5 range so malformed
+ * stored ratings cannot produce an out-of-range score.
+ *
+ * @route GET /api/apartment-rating-summary/:aptId
+ *
+ * @input {string} req.params.aptId – The ID of the apartment to summarize.
+ *
+ * @status
+ * - 200: Successfully computed the rating summary.
+ * - 500: Error retrieving or aggregating reviews.
+ */
+app.get('/api/apartment-rating-summary/:aptId', async (req, res) => {
+  const { aptId } = req.params;
+
+  try {
+    const reviewDocs = (
+      await reviewCollection.where('aptId', '==', aptId).where('status', '==', 'APPROVED').get()
+    ).docs;
+
+    if (reviewDocs.length === 0) {
+      res.status(200).send(
+        JSON.stringify({
+          aptId,
+          reviewCount: 0,
+          overall: 0,
+          location: 0,
+          maintenance: 0,
+          safety: 0,
+          conditions: 0,
+        })
+      );
+      return;
+    }
+
+    const totals = reviewDocs.reduce(
+      (acc, doc) => {
+        const data = doc.data() as Review;
+        const detailed = data.detailedRatings;
+        return {
+          overall: acc.overall + (data.overallRating || 0),
+          location: acc.location + (detailed?.location || 0),
+          maintenance: acc.maintenance + (detailed?.maintenance || 0),
+          safety: acc.safety + (detailed?.safety || 0),
+          conditions: acc.conditions + (detailed?.conditions || 0),
+        };
+      },
+      { overall: 0, location: 0, maintenance: 0, safety: 0, conditions: 0 }
+    );
+
+    const reviewCount = reviewDocs.length;
+    const average = (sum: number) => Math.min(5, Math.max(0, sum / reviewCount));
+
+    res.status(200).send(
+      JSON.stringify({
+        aptId,
+        reviewCount,
+        overall: average(totals.overall),
+        location: average(totals.location),
+        maintenance: average(totals.maintenance),
+        safety: average(totals.safety),
+        conditions: average(totals.conditions),
+      })
+    );
+  } catch (err) {
+    console.error(err);
+    res.status(500).send('Error retrieving apartment rating summary');
+  }
+});
+
 app.get('/api/review/:status', async (req, res) => {
   const { status } = req.params;
   const reviewDocs = (await reviewCollection.where('status', '==', status).get()).docs;
@@ -565,6 +642,157 @@ app.get('/api/apts/:ids', async (req, res) => {
     res.status(200).send(JSON.stringify(aptsArr));
   } catch (err) {
     res.status(400).send(err);
+  }
+});
+
+/**
+ * apartment-amenities – Retrieves the amenities list for a single apartment.
+ *
+ * @remarks
+ * Amenities are an optional field on the apartment document, so an apartment
+ * with no amenities recorded returns an empty list rather than an error. The
+ * apartment name is included so callers can render a heading without a
+ * second request.
+ *
+ * @route GET /api/apartment-amenities/:aptId
+ *
+ * @input {string} req.params.aptId – The ID of the apartment to read.
+ *
+ * @status
+ * - 200: Successfully retrieved amenities (empty list if none are set).
+ * - 404: No apartment exists with the given ID.
+ * - 500: Error retrieving amenities.
+ */
+app.get('/api/apartment-amenities/:aptId', async (req, res) => {
+  const { aptId } = req.params;
+
+  try {
+    const snapshot = await buildingsCollection.doc(aptId).get();
+
+    if (!snapshot.exists) {
+      res.status(404).send(JSON.stringify({ error: 'Apartment not found' }));
+      return;
+    }
+
+    const data = snapshot.data() as Partial<Apartment> | undefined;
+
+    res.status(200).send(
+      JSON.stringify({
+        aptId,
+        name: data?.name ?? null,
+        amenities: data?.amenities ?? [],
+      })
+    );
+  } catch (err) {
+    console.error(err);
+    res.status(500).send('Error retrieving apartment amenities');
+  }
+});
+
+/**
+ * apartment-floorplans – Retrieves the floor plans for a single apartment.
+ *
+ * @remarks
+ * Floor plans are an optional field on the apartment document. An apartment
+ * with none recorded returns an empty array so the frontend can render its
+ * "no floor plans" state without special-casing a missing field.
+ *
+ * @route GET /api/apartment-floorplans/:aptId
+ *
+ * @input {string} req.params.aptId – The ID of the apartment to read.
+ *
+ * @status
+ * - 200: Successfully retrieved floor plans (empty list if none are set).
+ * - 404: No apartment exists with the given ID.
+ * - 500: Error retrieving floor plans.
+ */
+app.get('/api/apartment-floorplans/:aptId', async (req, res) => {
+  const { aptId } = req.params;
+
+  try {
+    const snapshot = await buildingsCollection.doc(aptId).get();
+
+    if (!snapshot.exists) {
+      res.status(404).send(JSON.stringify({ error: 'Apartment not found' }));
+      return;
+    }
+
+    const data = snapshot.data() as Partial<Apartment> | undefined;
+    const floorplans = Array.isArray(data?.floorplans) ? data?.floorplans : [];
+
+    res.status(200).send(JSON.stringify({ aptId, floorplans }));
+  } catch (err) {
+    console.error(err);
+    res.status(500).send('Error retrieving apartment floorplans');
+  }
+});
+
+/**
+ * bus-stop-travel-times – Calculates walking times from a building to nearby bus stops.
+ *
+ * @remarks
+ * Uses the Google Distance Matrix API to compute walking times from the
+ * building's address to each Collegetown bus stop, and identifies the closest
+ * one. Unlike the stored `busStopWalking` field this is computed live, so it
+ * reflects current routing rather than the value cached at ingestion time.
+ *
+ * @route GET /api/bus-stop-travel-times/:buildingId
+ *
+ * @input {string} req.params.buildingId – The ID of the building to measure from.
+ *
+ * @status
+ * - 200: Successfully retrieved travel times.
+ * - 400: The building has no address recorded.
+ * - 404: No building exists with the given ID.
+ * - 500: Error calling Google Maps or processing the results.
+ */
+app.get('/api/bus-stop-travel-times/:buildingId', async (req, res) => {
+  const { buildingId } = req.params;
+
+  try {
+    const buildingDoc = await buildingsCollection.doc(buildingId).get();
+
+    if (!buildingDoc.exists) {
+      res.status(404).json({ error: 'Building not found' });
+      return;
+    }
+
+    const buildingData = buildingDoc.data() as Partial<Apartment> | undefined;
+    const origin = buildingData?.address;
+
+    if (!origin) {
+      res.status(400).json({ error: 'Building address is missing' });
+      return;
+    }
+
+    const stopNames = Object.keys(BUS_STOPS);
+    const destinations = Object.values(BUS_STOPS);
+
+    const walkingTimes = await getTravelTimes(origin, destinations, 'walking');
+
+    if (!Array.isArray(walkingTimes) || walkingTimes.length !== destinations.length) {
+      console.error('Unexpected walkingTimes length for bus stops', {
+        walkingTimesLength: walkingTimes.length,
+        destinationsLength: destinations.length,
+      });
+      res.status(500).json({ error: 'Error retrieving bus stop travel times' });
+      return;
+    }
+
+    const busStops: Record<string, number> = {};
+    stopNames.forEach((name, index) => {
+      busStops[name] = walkingTimes[index];
+    });
+
+    res.status(200).json({
+      buildingId,
+      origin,
+      busStops,
+      closestStop: findClosestStop(busStops),
+    });
+  } catch (err) {
+    console.error('Error retrieving bus stop travel times:', err);
+    res.status(500).json({ error: 'Error retrieving bus stop travel times' });
   }
 });
 
@@ -2413,41 +2641,12 @@ interface TravelTimeInput {
 }
 
 /**
- * getTravelTimes – Calculates travel times between an origin and multiple destinations using Google Distance Matrix API.
- *
- * @remarks
- * Makes an HTTP request to the Google Distance Matrix API and processes the response to extract duration values.
- * Times are converted from seconds to minutes before being returned.
- *
- * @param {string} origin - Starting location as either an address or coordinates in "lat,lng" format
- * @param {string[]} destinations - Array of destination addresses to calculate times to
- * @param {'walking' | 'driving'} mode - Mode of transportation to use for calculations
- * @return {Promise<number[]>} - Array of travel times in minutes to each destination
- */
-async function getTravelTimes(
-  origin: string,
-  destinations: string[],
-  mode: 'walking' | 'driving'
-): Promise<number[]> {
-  const response = await axios.get(
-    `https://maps.googleapis.com/maps/api/distancematrix/json?origins=${encodeURIComponent(
-      origin
-    )}&destinations=${destinations
-      .map((dest) => encodeURIComponent(dest))
-      .join('|')}&mode=${mode}&key=${REACT_APP_MAPS_API_KEY}`
-  );
-
-  return response.data.rows[0].elements.map(
-    (element: { duration: { value: number } }) => element.duration.value / 60
-  );
-}
-
-/**
  * Travel Times Calculator - Calculates walking and driving times from a given origin to Cornell landmarks.
  *
  * @remarks
  * Uses Google Maps Distance Matrix API to calculate travel times to three landmarks: Engineering Quad,
- * Agriculture Quad, and Ho Plaza. Returns both walking and driving durations in minutes.
+ * Agriculture Quad, and Ho Plaza, plus the walking time to the nearest Collegetown bus stop.
+ * Returns both walking and driving durations in minutes.
  * Origin can be either an address or coordinates in "latitude,longitude" format.
  *
  * @route POST /api/travel-times
@@ -2471,14 +2670,27 @@ app.post('/api/calculate-travel-times', async (req, res) => {
     const destinations = Object.values(LANDMARKS);
     console.log('Destinations array:', destinations);
 
+    const busStopNames = Object.keys(BUS_STOPS);
+    const busStopAddresses = Object.values(BUS_STOPS);
+
     // Get walking and driving times using the helper function
-    const [walkingTimes, drivingTimes] = await Promise.all([
+    const [walkingTimes, drivingTimes, busStopWalkingTimes] = await Promise.all([
       getTravelTimes(origin, destinations, 'walking'),
       getTravelTimes(origin, destinations, 'driving'),
+      getTravelTimes(origin, busStopAddresses, 'walking'),
     ]);
 
     console.log('Raw walking times:', walkingTimes);
     console.log('Raw driving times:', drivingTimes);
+
+    // Reduce the per-stop walking times to the single closest stop. Falls back
+    // to -1 when the API returns an unexpected number of results, matching the
+    // sentinel used elsewhere for "not yet calculated".
+    const busStopTimes: Record<string, number> = {};
+    busStopNames.forEach((name, index) => {
+      busStopTimes[name] = busStopWalkingTimes[index];
+    });
+    const closestBusStop = findClosestStop(busStopTimes);
 
     const travelTimes: LocationTravelTimes = {
       engQuadWalking: walkingTimes[0],
@@ -2487,6 +2699,7 @@ app.post('/api/calculate-travel-times', async (req, res) => {
       agQuadDriving: drivingTimes[1],
       hoPlazaWalking: walkingTimes[2],
       hoPlazaDriving: drivingTimes[2],
+      busStopWalking: closestBusStop ? closestBusStop.timeMinutes : -1,
     };
 
     console.log('Final travel times:', travelTimes);

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -34,7 +34,12 @@ import { Faq } from './firebase-config/types';
 import authenticate from './auth';
 import authenticateAdmin, { isAdminEmail } from './authAdmin';
 import { admins } from '../../frontend/src/constants/HomeConsts';
-import { BUS_STOPS, getTravelTimes, findClosestStop } from './travel-times-utils';
+import {
+  BUS_STOPS,
+  getTravelTimes,
+  findClosestStop,
+  withIthacaContext,
+} from './travel-times-utils';
 
 // Imports for email sending
 
@@ -736,6 +741,9 @@ app.get('/api/apartment-floorplans/:aptId', async (req, res) => {
  * one. Unlike the stored `busStopWalking` field this is computed live, so it
  * reflects current routing rather than the value cached at ingestion time.
  *
+ * Stored addresses carry no city, so the address is qualified with Ithaca, NY
+ * before it reaches Google. The `origin` in the response is that qualified form.
+ *
  * @route GET /api/bus-stop-travel-times/:buildingId
  *
  * @input {string} req.params.buildingId – The ID of the building to measure from.
@@ -758,12 +766,17 @@ app.get('/api/bus-stop-travel-times/:buildingId', async (req, res) => {
     }
 
     const buildingData = buildingDoc.data() as Partial<Apartment> | undefined;
-    const origin = buildingData?.address;
+    const address = buildingData?.address;
 
-    if (!origin) {
+    if (!address) {
       res.status(400).json({ error: 'Building address is missing' });
       return;
     }
+
+    // Stored addresses omit the city, which Google resolves against the whole
+    // country. The qualified form is reported back so callers can see exactly
+    // what was measured from.
+    const origin = withIthacaContext(address);
 
     const stopNames = Object.keys(BUS_STOPS);
     const destinations = Object.values(BUS_STOPS);
@@ -2660,12 +2673,16 @@ interface TravelTimeInput {
  */
 app.post('/api/calculate-travel-times', async (req, res) => {
   try {
-    const { origin } = req.body as TravelTimeInput;
-    console.log('Origin:', origin);
+    const { origin: rawOrigin } = req.body as TravelTimeInput;
+    console.log('Origin:', rawOrigin);
 
-    if (!origin) {
+    if (!rawOrigin) {
       return res.status(400).json({ error: 'Origin is required' });
     }
+
+    // Coordinate origins pass through untouched; a bare address gets its city
+    // appended so Google does not resolve it against the whole country.
+    const origin = withIthacaContext(rawOrigin);
 
     const destinations = Object.values(LANDMARKS);
     console.log('Destinations array:', destinations);

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -680,12 +680,15 @@ app.get('/api/apartment-amenities/:aptId', async (req, res) => {
     }
 
     const data = snapshot.data() as Partial<Apartment> | undefined;
+    // Guarded the same way as floor plans below. A document holding a non-array
+    // value would otherwise reach the client as something it cannot map over.
+    const amenities = Array.isArray(data?.amenities) ? data?.amenities : [];
 
     res.status(200).send(
       JSON.stringify({
         aptId,
         name: data?.name ?? null,
-        amenities: data?.amenities ?? [],
+        amenities,
       })
     );
   } catch (err) {

--- a/backend/src/travel-times-utils.ts
+++ b/backend/src/travel-times-utils.ts
@@ -8,6 +8,35 @@ export const BUS_STOPS: Record<string, string> = {
   'College @ Mitchell': 'College Ave & Mitchell St, Ithaca, NY 14850',
 };
 
+const ITHACA_QUALIFIER = 'Ithaca, NY 14850';
+
+/** Matches an origin already expressed as "latitude,longitude" rather than an address. */
+const COORDINATE_PATTERN = /^-?\d+(\.\d+)?\s*,\s*-?\d+(\.\d+)?$/;
+
+/**
+ * withIthacaContext – Qualifies a bare street address with its city, state, and ZIP.
+ *
+ * @remarks
+ * Apartment addresses are stored without a city (e.g. "408 College Ave"), which the
+ * Google Maps APIs resolve against the whole country — "408 College Ave" geocodes to
+ * Texas, yielding walking times measured in days. Appending the city disambiguates it.
+ *
+ * Origins already given as "latitude,longitude", and addresses that already name
+ * Ithaca, are returned untouched so this is safe to apply to any origin.
+ *
+ * @param location - An address, or coordinates in "latitude,longitude" format
+ * @returns The location qualified with Ithaca, NY, or unchanged if not applicable
+ */
+export function withIthacaContext(location: string): string {
+  const trimmed = location.trim().replace(/,+$/, '').trim();
+
+  if (!trimmed) return location;
+  if (COORDINATE_PATTERN.test(trimmed)) return trimmed;
+  if (/\bithaca\b/i.test(trimmed)) return trimmed;
+
+  return `${trimmed}, ${ITHACA_QUALIFIER}`;
+}
+
 /**
  * getTravelTimes – Calculates travel times between an origin and multiple destinations
  * using the Google Distance Matrix API.

--- a/backend/src/travel-times-utils.ts
+++ b/backend/src/travel-times-utils.ts
@@ -1,0 +1,57 @@
+import axios from 'axios';
+
+export const BUS_STOPS: Record<string, string> = {
+  'College and Oak': 'College Ave & Oak Ave, Ithaca, NY 14850',
+  'Schwartz Performing Arts Center': '430 College Ave, Ithaca, NY 14850',
+  'Collegetown Crossing': '307 College Ave Ste 1, Ithaca, NY 14850',
+  'Catherine Commons': '304 College Ave, Ithaca, NY 14850',
+  'College @ Mitchell': 'College Ave & Mitchell St, Ithaca, NY 14850',
+};
+
+/**
+ * getTravelTimes – Calculates travel times between an origin and multiple destinations
+ * using the Google Distance Matrix API.
+ *
+ * Times are converted from seconds to minutes before being returned.
+ *
+ * @param origin - Starting location as an address or "lat,lng" string
+ * @param destinations - Array of destination addresses
+ * @param mode - Transportation mode ('walking' | 'driving')
+ * @returns Array of travel times in minutes, one per destination
+ */
+export async function getTravelTimes(
+  origin: string,
+  destinations: string[],
+  mode: 'walking' | 'driving'
+): Promise<number[]> {
+  const { REACT_APP_MAPS_API_KEY } = process.env;
+  const response = await axios.get(
+    `https://maps.googleapis.com/maps/api/distancematrix/json?origins=${encodeURIComponent(
+      origin
+    )}&destinations=${destinations
+      .map((dest) => encodeURIComponent(dest))
+      .join('|')}&mode=${mode}&key=${REACT_APP_MAPS_API_KEY}`
+  );
+
+  return response.data.rows[0].elements.map(
+    (element: { duration: { value: number } }) => element.duration.value / 60
+  );
+}
+
+export interface ClosestStop {
+  name: string;
+  timeMinutes: number;
+}
+
+/**
+ * findClosestStop – Given a map of stop names to walking times (minutes), returns
+ * the stop with the minimum time, or null if the map is empty or all times are
+ * non-finite.
+ */
+export function findClosestStop(busStops: Record<string, number>): ClosestStop | null {
+  return Object.entries(busStops).reduce<ClosestStop | null>((best, [name, time]) => {
+    if (typeof time !== 'number' || !Number.isFinite(time)) return best;
+    if (best === null || time < best.timeMinutes) return { name, timeMinutes: time };
+    return best;
+  }, null);
+}

--- a/common/types/db-types.ts
+++ b/common/types/db-types.ts
@@ -99,12 +99,15 @@ export type ApartmentTotalRating = {
  * filtering and price sorting; floor plans are supplementary detail-page data.
  */
 export type ApartmentFloorPlan = {
-  readonly photo: string;
   readonly bedrooms: number;
   readonly bathrooms: number;
   readonly costPerPerson: number;
-  readonly unitsAvailable: number;
-  readonly sqft: number;
+  // Optional: no current data source supplies these. Floor plans derived from
+  // roomTypes carry bed/bath/price only, and the agency scrapers publish
+  // neither square footage nor floor plan imagery.
+  readonly photo?: string;
+  readonly unitsAvailable?: number;
+  readonly sqft?: number;
 };
 
 export type Apartment = {

--- a/common/types/db-types.ts
+++ b/common/types/db-types.ts
@@ -75,6 +75,38 @@ export type RoomType = {
   readonly price: number; // >= 1, integer (in dollars)
 };
 
+/**
+ * Aggregate rating totals stored on an apartment document.
+ *
+ * @remarks
+ * These are denormalized snapshots. Live rating figures are computed from the
+ * reviews collection via `GET /api/apartment-rating-summary/:aptId`.
+ */
+export type ApartmentTotalRating = {
+  readonly overallHearts: number;
+  readonly overallLocation: number;
+  readonly overallMaintenance: number;
+  readonly overallSafety: number;
+  readonly overallConditions: number;
+};
+
+/**
+ * A single floor plan offered by an apartment.
+ *
+ * @remarks
+ * Floor plans carry presentation details (photo, square footage, availability)
+ * that `RoomType` does not. `RoomType` remains the source of truth for search
+ * filtering and price sorting; floor plans are supplementary detail-page data.
+ */
+export type ApartmentFloorPlan = {
+  readonly photo: string;
+  readonly bedrooms: number;
+  readonly bathrooms: number;
+  readonly costPerPerson: number;
+  readonly unitsAvailable: number;
+  readonly sqft: number;
+};
+
 export type Apartment = {
   readonly name: string;
   readonly address: string; // may change to placeID for Google Maps integration
@@ -85,6 +117,12 @@ export type Apartment = {
   readonly latitude: number;
   readonly longitude: number;
   readonly distanceToCampus: number; // walking distance to ho plaza in minutes
+  // Optional detail-page fields. Absent on documents that predate the
+  // apartment page redesign, so every consumer must handle `undefined`.
+  readonly description?: string;
+  readonly amenities?: readonly string[]; // parking, laundry, heat, kitchen, internet
+  readonly floorplans?: readonly ApartmentFloorPlan[];
+  readonly totalRating?: ApartmentTotalRating;
 };
 
 export type LocationTravelTimes = {
@@ -94,6 +132,9 @@ export type LocationTravelTimes = {
   engQuadWalking: number;
   hoPlazaDriving: number;
   hoPlazaWalking: number;
+  // Walking time to the nearest bus stop. Optional because travelTimes
+  // documents written before bus stop support lack the field.
+  busStopWalking?: number;
 };
 
 export type ApartmentWithId = Apartment & Id;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,7 +20,7 @@ import { ModalProvider } from './components/utils/Footer/ContactModalContext';
 import { hotjar } from 'react-hotjar';
 import { HJID, HJSV } from './constants/hotjar';
 import Policies from './pages/Policies';
-import ApartmentPage from './pages/ApartmentPage';
+import NewApartmentPage from './pages/newApartmentPage';
 import AdminPage from './pages/AdminPage';
 import LocationPage from './pages/LocationPage';
 import axios from 'axios';
@@ -168,9 +168,12 @@ const App = (): ReactElement => {
               path="/bookmarks"
               component={() => <BookmarksPage user={user} setUser={setUser} />}
             />
+            {/* `render` rather than `component` so the element type stays stable
+                across App re-renders; an inline `component` arrow remounts the
+                page and refetches on every user state change. */}
             <Route
               path="/apartment/:aptId"
-              component={() => <ApartmentPage user={user} setUser={setUser} />}
+              render={() => <NewApartmentPage user={user} setUser={setUser} />}
             />
             <Route exact path="/notfound" component={NotFoundPage} />
             <Route

--- a/frontend/src/components/Apartment/FloorPlanCard.tsx
+++ b/frontend/src/components/Apartment/FloorPlanCard.tsx
@@ -1,0 +1,108 @@
+import React, { ReactElement } from 'react';
+import { Typography, makeStyles } from '@material-ui/core';
+import { apartmentFloorPlan } from '../../../../common/types/db-types';
+import { colors } from '../../colors';
+
+type Props = {
+  readonly plan: apartmentFloorPlan;
+};
+
+const useStyles = makeStyles({
+  card: {
+    background: colors.white,
+    borderRadius: 12,
+    padding: '16px 20px',
+    display: 'flex',
+    alignItems: 'center',
+    gap: 16,
+    marginBottom: 12,
+  },
+  image: {
+    width: 88,
+    height: 88,
+    objectFit: 'cover',
+    borderRadius: 8,
+    flexShrink: 0,
+    background: colors.gray5,
+  },
+  info: {
+    flex: 1,
+  },
+  title: {
+    fontWeight: 700,
+    fontSize: 16,
+    color: colors.black,
+    marginBottom: 2,
+  },
+  meta: {
+    fontSize: 14,
+    color: colors.gray1,
+    lineHeight: 1.4,
+  },
+  priceBlock: {
+    textAlign: 'right',
+    flexShrink: 0,
+  },
+  priceValue: {
+    fontWeight: 700,
+    fontSize: 22,
+    color: colors.black,
+    lineHeight: 1.1,
+  },
+  priceNA: {
+    fontWeight: 700,
+    fontSize: 22,
+    color: colors.gray2,
+    lineHeight: 1.1,
+  },
+  priceSub: {
+    fontSize: 13,
+    color: colors.gray1,
+  },
+});
+
+/**
+ * FloorPlanCard renders a single floor plan row showing:
+ * - Optional floor plan thumbnail image
+ * - Bed/bath count, sqft, units available
+ * - Price per person (or N/A when costPerPerson is 0)
+ */
+const FloorPlanCard = ({ plan }: Props): ReactElement => {
+  const { card, image, info, title, meta, priceBlock, priceValue, priceNA, priceSub } = useStyles();
+  const { photo, bedrooms, bathrooms, costPerPerson, unitsAvaliable, sqft } = plan;
+  const hasPrice = costPerPerson > 0;
+
+  return (
+    <div className={card}>
+      {photo && <img src={photo} alt="floor plan" className={image} />}
+
+      <div className={info}>
+        <Typography className={title}>
+          {bedrooms} Beds {bathrooms} bath
+        </Typography>
+        <Typography className={meta}>{sqft} sqft</Typography>
+        <Typography className={meta}>{unitsAvaliable} units available</Typography>
+      </div>
+
+      <div className={priceBlock}>
+        {hasPrice ? (
+          <>
+            <Typography className={priceValue} data-testid="floorplan-price">
+              ${costPerPerson.toLocaleString()}
+            </Typography>
+            <Typography className={priceSub}>per person</Typography>
+          </>
+        ) : (
+          <>
+            <Typography className={priceNA} data-testid="floorplan-price">
+              N/A
+            </Typography>
+            <Typography className={priceSub}>no data for pricing</Typography>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default FloorPlanCard;

--- a/frontend/src/components/Apartment/FloorPlanCard.tsx
+++ b/frontend/src/components/Apartment/FloorPlanCard.tsx
@@ -1,10 +1,10 @@
 import React, { ReactElement } from 'react';
 import { Typography, makeStyles } from '@material-ui/core';
-import { apartmentFloorPlan } from '../../../../common/types/db-types';
+import { ApartmentFloorPlan } from '../../../../common/types/db-types';
 import { colors } from '../../colors';
 
 type Props = {
-  readonly plan: apartmentFloorPlan;
+  readonly plan: ApartmentFloorPlan;
 };
 
 const useStyles = makeStyles({
@@ -62,14 +62,32 @@ const useStyles = makeStyles({
 });
 
 /**
- * FloorPlanCard renders a single floor plan row showing:
- * - Optional floor plan thumbnail image
- * - Bed/bath count, sqft, units available
- * - Price per person (or N/A when costPerPerson is 0)
+ * pluralize – Formats a count with its unit label, adding "s" when the count is not 1.
+ *
+ * @param {number} count – The quantity to describe.
+ * @param {string} unit – The singular form of the unit.
+ *
+ * @return {string} – The count and correctly pluralized unit, e.g. "1 bed" or "2 beds".
+ */
+const pluralize = (count: number, unit: string): string =>
+  `${count} ${unit}${count === 1 ? '' : 's'}`;
+
+/**
+ * FloorPlanCard Component – Displays a single floor plan offered by an apartment.
+ *
+ * @remarks
+ * Shows an optional thumbnail, the bed/bath configuration, square footage and
+ * unit availability, and the per-person price. Square footage and availability
+ * are omitted entirely when absent rather than rendering "undefined", and the
+ * price falls back to an N/A state when no pricing data exists.
+ *
+ * @param {ApartmentFloorPlan} props.plan – The floor plan to render.
+ *
+ * @return {ReactElement} – The rendered FloorPlanCard component.
  */
 const FloorPlanCard = ({ plan }: Props): ReactElement => {
   const { card, image, info, title, meta, priceBlock, priceValue, priceNA, priceSub } = useStyles();
-  const { photo, bedrooms, bathrooms, costPerPerson, unitsAvaliable, sqft } = plan;
+  const { photo, bedrooms, bathrooms, costPerPerson, unitsAvailable, sqft } = plan;
   const hasPrice = costPerPerson > 0;
 
   return (
@@ -78,10 +96,12 @@ const FloorPlanCard = ({ plan }: Props): ReactElement => {
 
       <div className={info}>
         <Typography className={title}>
-          {bedrooms} Beds {bathrooms} bath
+          {pluralize(bedrooms, 'Bed')} {pluralize(bathrooms, 'bath')}
         </Typography>
-        <Typography className={meta}>{sqft} sqft</Typography>
-        <Typography className={meta}>{unitsAvaliable} units available</Typography>
+        {Number.isFinite(sqft) && <Typography className={meta}>{sqft} sqft</Typography>}
+        {Number.isFinite(unitsAvailable) && (
+          <Typography className={meta}>{pluralize(unitsAvailable, 'unit')} available</Typography>
+        )}
       </div>
 
       <div className={priceBlock}>

--- a/frontend/src/components/Apartment/FloorPlanCard.tsx
+++ b/frontend/src/components/Apartment/FloorPlanCard.tsx
@@ -25,6 +25,23 @@ const useStyles = makeStyles({
     flexShrink: 0,
     background: colors.gray5,
   },
+  imagePlaceholder: {
+    width: 88,
+    height: 88,
+    borderRadius: 8,
+    flexShrink: 0,
+    background: colors.gray5,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    textAlign: 'center',
+    padding: 6,
+  },
+  imagePlaceholderText: {
+    fontSize: 11,
+    lineHeight: 1.3,
+    color: colors.gray2,
+  },
   info: {
     flex: 1,
   },
@@ -73,6 +90,21 @@ const pluralize = (count: number, unit: string): string =>
   `${count} ${unit}${count === 1 ? '' : 's'}`;
 
 /**
+ * isMeasured – Narrows an optional numeric floor plan field to a usable number.
+ *
+ * @remarks
+ * Floor plans derived from room types carry no square footage or unit count,
+ * and stored plans may hold a non-numeric value. Both cases must be omitted
+ * from the rendered card rather than displayed as "undefined" or "NaN".
+ *
+ * @param {number | undefined} value – The field to test.
+ *
+ * @return {boolean} – True when the value is a finite number.
+ */
+const isMeasured = (value: number | undefined): value is number =>
+  typeof value === 'number' && Number.isFinite(value);
+
+/**
  * FloorPlanCard Component – Displays a single floor plan offered by an apartment.
  *
  * @remarks
@@ -86,20 +118,38 @@ const pluralize = (count: number, unit: string): string =>
  * @return {ReactElement} – The rendered FloorPlanCard component.
  */
 const FloorPlanCard = ({ plan }: Props): ReactElement => {
-  const { card, image, info, title, meta, priceBlock, priceValue, priceNA, priceSub } = useStyles();
+  const {
+    card,
+    image,
+    imagePlaceholder,
+    imagePlaceholderText,
+    info,
+    title,
+    meta,
+    priceBlock,
+    priceValue,
+    priceNA,
+    priceSub,
+  } = useStyles();
   const { photo, bedrooms, bathrooms, costPerPerson, unitsAvailable, sqft } = plan;
   const hasPrice = costPerPerson > 0;
 
   return (
     <div className={card}>
-      {photo && <img src={photo} alt="floor plan" className={image} />}
+      {photo ? (
+        <img src={photo} alt="floor plan" className={image} />
+      ) : (
+        <div className={imagePlaceholder} data-testid="floorplan-image-placeholder">
+          <Typography className={imagePlaceholderText}>No image available</Typography>
+        </div>
+      )}
 
       <div className={info}>
         <Typography className={title}>
           {pluralize(bedrooms, 'Bed')} {pluralize(bathrooms, 'bath')}
         </Typography>
-        {Number.isFinite(sqft) && <Typography className={meta}>{sqft} sqft</Typography>}
-        {Number.isFinite(unitsAvailable) && (
+        {isMeasured(sqft) && <Typography className={meta}>{sqft} sqft</Typography>}
+        {isMeasured(unitsAvailable) && (
           <Typography className={meta}>{pluralize(unitsAvailable, 'unit')} available</Typography>
         )}
       </div>

--- a/frontend/src/components/Apartment/MapInfo.tsx
+++ b/frontend/src/components/Apartment/MapInfo.tsx
@@ -301,6 +301,20 @@ function MapInfo({
               walkDistance={Math.round(travelTimes?.agQuadWalking || 0)}
             />
           </Box>
+          {/* Only shown when a bus stop time has actually been calculated;
+              travelTimes documents predating bus stop support omit the field,
+              and -1 is the sentinel for "not yet calculated". */}
+          {(travelTimes?.busStopWalking ?? 0) > 0 && (
+            <Box style={{ lineHeight: 'normal', letterSpacing: '0.38px', marginTop: '8px' }}>
+              <Typography variant="h6" style={{ fontWeight: 400, fontSize: '16.964px' }}>
+                Distance to Transportation
+              </Typography>
+              <WalkDistanceInfo
+                location={'Bus Station'}
+                walkDistance={Math.round(travelTimes?.busStopWalking ?? 0)}
+              />
+            </Box>
+          )}
         </Box>
       </Box>
     </Box>

--- a/frontend/src/components/Apartment/RatingSummary.tsx
+++ b/frontend/src/components/Apartment/RatingSummary.tsx
@@ -1,0 +1,127 @@
+import React, { ReactElement } from 'react';
+import { Grid, Typography, makeStyles } from '@material-ui/core';
+import HeartRating from '../utils/HeartRating';
+import LabeledLinearProgress from '../utils/LabeledLinearProgress';
+import { RatingInfo } from '../../pages/ApartmentPage';
+import { colors } from '../../colors';
+
+type Props = {
+  readonly aveRatingInfo: RatingInfo[];
+  readonly averageRating: number;
+  readonly numReviews: number;
+};
+
+const useStyles = makeStyles({
+  card: {
+    background: colors.white,
+    borderRadius: 12,
+    padding: '20px 24px',
+    marginBottom: 16,
+  },
+  leftPanel: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRight: `1px solid ${colors.gray5}`,
+    paddingRight: 24,
+    minWidth: 120,
+  },
+  avgNumber: {
+    fontSize: 48,
+    fontWeight: 700,
+    lineHeight: 1,
+    color: colors.black,
+    marginBottom: 8,
+  },
+  naText: {
+    fontSize: 48,
+    fontWeight: 700,
+    lineHeight: 1,
+    color: colors.gray4,
+    fontStyle: 'italic',
+    marginBottom: 8,
+  },
+  rightPanel: {
+    flex: 1,
+    paddingLeft: 24,
+  },
+  featureRow: {
+    display: 'flex',
+    alignItems: 'center',
+    marginBottom: 6,
+    gap: 8,
+  },
+  featureLabel: {
+    width: 100,
+    flexShrink: 0,
+    fontSize: 14,
+    color: colors.black,
+  },
+  barWrapper: {
+    flex: 1,
+  },
+});
+
+/**
+ * RatingSummary displays the overall average rating for an apartment alongside
+ * per-category (Location, Maintenance, Safety, Conditions) progress bars.
+ *
+ * Two states:
+ * - Active (numReviews > 0): large bold average number, filled HeartRating, colored bars
+ * - N/A (numReviews === 0): "N/A" in gray, empty HeartRating, all bars empty
+ */
+const RatingSummary = ({ aveRatingInfo, averageRating, numReviews }: Props): ReactElement => {
+  const { card, leftPanel, avgNumber, naText, rightPanel, featureRow, featureLabel, barWrapper } =
+    useStyles();
+
+  const hasReviews = numReviews > 0 && aveRatingInfo.length > 0;
+
+  return (
+    <div className={card}>
+      <Grid container alignItems="center" wrap="nowrap">
+        <Grid item className={leftPanel}>
+          {hasReviews ? (
+            <>
+              <Typography className={avgNumber} data-testid="rating-average">
+                {averageRating.toFixed(1)}
+              </Typography>
+              <HeartRating value={averageRating} precision={0.5} readOnly />
+            </>
+          ) : (
+            <>
+              <Typography className={naText} data-testid="rating-na">
+                N/A
+              </Typography>
+              <HeartRating value={0} precision={0.5} readOnly />
+            </>
+          )}
+        </Grid>
+
+        <Grid item className={rightPanel}>
+          {hasReviews
+            ? aveRatingInfo.map(({ feature, rating }) => (
+                <div key={feature} className={featureRow}>
+                  <Typography className={featureLabel}>
+                    {feature.charAt(0).toUpperCase() + feature.slice(1)}
+                  </Typography>
+                  <div className={barWrapper}>
+                    <LabeledLinearProgress value={rating} />
+                  </div>
+                </div>
+              ))
+            : ['Location', 'Maintenance', 'Safety', 'Conditions'].map((label) => (
+                <div key={label} className={featureRow}>
+                  <Typography className={featureLabel}>{label}</Typography>
+                  <div className={barWrapper}>
+                    <LabeledLinearProgress value={0} />
+                  </div>
+                </div>
+              ))}
+        </Grid>
+      </Grid>
+    </div>
+  );
+};
+
+export default RatingSummary;

--- a/frontend/src/pages/newApartmentPage.tsx
+++ b/frontend/src/pages/newApartmentPage.tsx
@@ -1,0 +1,866 @@
+import React, { ReactElement, useEffect, useMemo, useState } from 'react';
+import { Button, Container, Grid, Typography, makeStyles } from '@material-ui/core';
+import DirectionsCarIcon from '@material-ui/icons/DirectionsCar';
+import LocalLaundryServiceIcon from '@material-ui/icons/LocalLaundryService';
+import KitchenIcon from '@material-ui/icons/Kitchen';
+import WifiIcon from '@material-ui/icons/Wifi';
+import WhatshotIcon from '@material-ui/icons/Whatshot';
+import PetsIcon from '@material-ui/icons/Pets';
+import WeekendIcon from '@material-ui/icons/Weekend';
+import { useParams, useHistory } from 'react-router-dom';
+import axios from 'axios';
+import {
+  ApartmentWithId,
+  Landlord,
+  LocationTravelTimes,
+  ReviewWithId,
+} from '../../../common/types/db-types';
+import { getAverageRating } from '../utils/average';
+import { get } from '../utils/call';
+import { colors } from '../colors';
+import { CardData } from '../App';
+import { createAuthHeaders, getUser, subscribeLikes } from '../utils/firebase';
+import { Likes } from '../../../common/types/db-types';
+import { sortReviews } from '../utils/sortReviews';
+import { RatingInfo } from './ApartmentPage';
+
+import ReviewComponent from '../components/Review/Review';
+import ReviewModal from '../components/LeaveReview/ReviewModal';
+import PhotoCarousel from '../components/PhotoCarousel/PhotoCarousel';
+import usePhotoCarousel from '../components/PhotoCarousel/usePhotoCarousel';
+import MapInfo from '../components/Apartment/MapInfo';
+import MapModal from '../components/Apartment/MapModal';
+import NewApartmentCard from '../components/ApartmentCard/NewApartmentCard';
+import RatingSummary from '../components/Apartment/RatingSummary';
+import FloorPlanCard from '../components/Apartment/FloorPlanCard';
+import Toast from '../components/utils/Toast';
+import savedIcon from '../assets/saved-icon-filled.svg';
+import unsavedIcon from '../assets/saved-icon-unfilled.svg';
+
+type Props = {
+  user: firebase.User | null;
+  setUser: React.Dispatch<React.SetStateAction<firebase.User | null>>;
+};
+
+type Fields = keyof ReviewWithId;
+
+const AMENITY_ICONS: Record<string, ReactElement> = {
+  parking: <DirectionsCarIcon fontSize="small" />,
+  heat: <WhatshotIcon fontSize="small" />,
+  internet: <WifiIcon fontSize="small" />,
+  furnished: <WeekendIcon fontSize="small" />,
+  laundry: <LocalLaundryServiceIcon fontSize="small" />,
+  kitchen: <KitchenIcon fontSize="small" />,
+  'no pets': <PetsIcon fontSize="small" />,
+};
+
+const useStyles = makeStyles({
+  page: {
+    backgroundColor: colors.gray3,
+    minHeight: '100vh',
+    paddingBottom: 48,
+  },
+  innerPage: {
+    maxWidth: 1200,
+    margin: '0 auto',
+    padding: '0 16px',
+  },
+
+  /* ── Hero ── */
+  heroPrimary: {
+    width: '100%',
+    height: '100%',
+    objectFit: 'cover',
+    borderRadius: 12,
+    display: 'block',
+  },
+  heroSecondaryCol: {
+    display: 'grid',
+    gridTemplateRows: '1fr 1fr',
+    gap: 6,
+  },
+  heroSecondary: {
+    width: '100%',
+    height: '100%',
+    objectFit: 'cover',
+    borderRadius: 12,
+    display: 'block',
+  },
+  heroPlaceholder: {
+    width: '100%',
+    height: '100%',
+    borderRadius: 12,
+    background: colors.gray5,
+    display: 'block',
+  },
+  galleryBtn: {
+    position: 'absolute',
+    right: 12,
+    bottom: 12,
+    background: 'rgba(0,0,0,0.72)',
+    color: colors.white,
+    borderRadius: 999,
+    padding: '6px 14px',
+    fontWeight: 600,
+    fontSize: 13,
+    cursor: 'pointer',
+    border: 0,
+    '&:hover': { background: 'rgba(0,0,0,0.88)' },
+  },
+
+  /* ── Apt header row ── */
+  aptHeaderRow: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+    gap: 16,
+    marginBottom: 12,
+  },
+  aptTitle: {
+    fontWeight: 700,
+    fontSize: 32,
+    lineHeight: 1.15,
+    margin: 0,
+    marginBottom: 8,
+    color: colors.black,
+  },
+  aptDescription: {
+    fontSize: 15,
+    color: colors.gray1,
+    marginBottom: 0,
+    maxWidth: 680,
+    lineHeight: 1.55,
+  },
+  actionBtns: {
+    display: 'flex',
+    gap: 8,
+    flexShrink: 0,
+    alignItems: 'flex-start',
+    paddingTop: 4,
+  },
+  saveBtn: {
+    background: colors.red1,
+    color: colors.white,
+    borderRadius: 999,
+    padding: '8px 16px',
+    fontWeight: 600,
+    fontSize: 14,
+    textTransform: 'none',
+    display: 'flex',
+    alignItems: 'center',
+    gap: 6,
+    '&:hover': { background: colors.red7 },
+  },
+  outlineBtn: {
+    background: 'transparent',
+    border: `1.5px solid ${colors.gray4}`,
+    color: colors.black,
+    borderRadius: 999,
+    padding: '7px 16px',
+    fontWeight: 500,
+    fontSize: 14,
+    textTransform: 'none',
+    '&:hover': { background: colors.gray5 },
+  },
+  outlineBtnRed: {
+    background: 'transparent',
+    border: `1.5px solid ${colors.red1}`,
+    color: colors.red1,
+    borderRadius: 999,
+    padding: '7px 16px',
+    fontWeight: 600,
+    fontSize: 14,
+    textTransform: 'none',
+    '&:hover': { background: colors.red6 },
+  },
+  bookmarkIcon: {
+    width: 16,
+    height: 20,
+    filter: 'brightness(0) invert(1)',
+  },
+
+  /* ── Section headings ── */
+  sectionHeading: {
+    fontWeight: 700,
+    fontSize: 22,
+    marginBottom: 12,
+    marginTop: 4,
+    color: colors.black,
+  },
+
+  /* ── Reviews ── */
+  reviewsHeader: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 12,
+  },
+  emptyText: {
+    color: colors.gray1,
+    fontSize: 15,
+    marginBottom: 12,
+  },
+  showMoreBtn: {
+    width: '100%',
+    borderRadius: 999,
+    border: `1.5px solid ${colors.gray4}`,
+    color: colors.gray1,
+    fontWeight: 600,
+    textTransform: 'none',
+    marginTop: 8,
+    marginBottom: 8,
+    '&:hover': { background: colors.gray5 },
+  },
+
+  /* ── Amenities ── */
+  amenitiesGrid: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: 10,
+    marginBottom: 8,
+  },
+  amenityPill: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 6,
+    background: colors.white,
+    border: `1px solid ${colors.gray5}`,
+    borderRadius: 999,
+    padding: '6px 14px',
+    fontSize: 14,
+    color: colors.black,
+  },
+
+  /* ── Landlord card ── */
+  landlordCard: {
+    background: colors.white,
+    borderRadius: 12,
+    padding: '16px 20px',
+    marginBottom: 8,
+  },
+  landlordInfoLabel: {
+    fontWeight: 500,
+    fontSize: 14,
+    color: colors.gray1,
+    marginBottom: 4,
+  },
+  landlordName: {
+    fontWeight: 600,
+    fontSize: 15,
+    color: colors.black,
+    marginBottom: 2,
+  },
+  landlordAddress: {
+    fontSize: 14,
+    color: colors.gray1,
+    marginBottom: 12,
+  },
+  msgLandlordBtn: {
+    background: colors.red1,
+    color: colors.white,
+    borderRadius: 999,
+    width: '100%',
+    marginBottom: 8,
+    textTransform: 'none',
+    fontWeight: 600,
+    '&:hover': { background: colors.red7 },
+  },
+  visitBtn: {
+    border: `1.5px solid ${colors.red1}`,
+    color: colors.red1,
+    borderRadius: 999,
+    width: '100%',
+    textTransform: 'none',
+    fontWeight: 600,
+    '&:hover': { background: colors.red6 },
+  },
+
+  /* ── Similar properties ── */
+  similarRow: {
+    display: 'flex',
+    gap: 16,
+    overflowX: 'auto',
+    paddingBottom: 8,
+  },
+  similarCardWrapper: {
+    flexShrink: 0,
+  },
+
+  /* ── Loading / padding ── */
+  loadingText: {
+    padding: 40,
+    textAlign: 'center',
+    color: colors.gray1,
+  },
+});
+
+/**
+ * NewApartmentPage is the fully-redesigned apartment detail page.
+ *
+ * Displays: hero image gallery, apartment title/description, rating summary,
+ * reviews, floor plans, amenities, location map, landlord info, and similar properties.
+ * Matches the Figma design with edge-case handling for missing data.
+ */
+const NewApartmentPage = ({ user, setUser }: Props): ReactElement => {
+  const classes = useStyles();
+  const { aptId } = useParams<Record<string, string>>();
+  const history = useHistory();
+
+  /* ── State ── */
+  const [apt, setApt] = useState<ApartmentWithId | null>(null);
+  const [reviewData, setReviewData] = useState<ReviewWithId[]>([]);
+  const [landlordData, setLandlordData] = useState<Landlord | null>(null);
+  const [otherProperties, setOtherProperties] = useState<CardData[]>([]);
+  const [travelTimes, setTravelTimes] = useState<LocationTravelTimes | undefined>(undefined);
+  const [isSaved, setIsSaved] = useState(false);
+  const sortBy: Fields = 'date';
+  const [resultsToShow, setResultsToShow] = useState(5);
+  const [likedReviews, setLikedReviews] = useState<Likes>({});
+  const [likeStatuses, setLikeStatuses] = useState<Likes>({});
+  const [reviewOpen, setReviewOpen] = useState(false);
+  const [mapOpen, setMapOpen] = useState(false);
+  const [mapToggle, setMapToggle] = useState(false);
+  const [toggle, setToggle] = useState(false);
+  const [showConfirmation, setShowConfirmation] = useState(false);
+  const [showSignInError, setShowSignInError] = useState(false);
+  const [showEditSuccess, setShowEditSuccess] = useState(false);
+  const [showDeleteSuccess, setShowDeleteSuccess] = useState(false);
+  const [showReportSuccess, setShowReportSuccess] = useState(false);
+  const [showSaveSuccess, setShowSaveSuccess] = useState(false);
+
+  const toastTime = 3500;
+
+  const {
+    carouselPhotos,
+    carouselStartIndex,
+    carouselOpen,
+    showPhotoCarousel,
+    closePhotoCarousel,
+  } = usePhotoCarousel(apt?.photos ?? []);
+
+  /* ── Data fetching ── */
+  useEffect(() => {
+    get<ApartmentWithId[]>(`/api/apts/${aptId}`, {
+      callback: (data) => setApt(data[0] ?? null),
+    });
+    get<LocationTravelTimes>(`/api/travel-times-by-id/${aptId}`, {
+      callback: setTravelTimes,
+    });
+  }, [aptId]);
+
+  useEffect(() => {
+    const fetchReviews = async () => {
+      const [approved, reported] = await Promise.all([
+        axios.get<ReviewWithId[]>(`/api/review/aptId/${aptId}/APPROVED`),
+        axios.get<ReviewWithId[]>(`/api/review/aptId/${aptId}/REPORTED`),
+      ]);
+      setReviewData([...approved.data, ...reported.data]);
+    };
+    fetchReviews();
+  }, [aptId, toggle]);
+
+  useEffect(() => {
+    if (!apt?.landlordId) return;
+    get<Landlord>(`/api/landlord/${apt.landlordId}`, { callback: setLandlordData });
+    get<CardData[]>(`/api/buildings/all/${apt.landlordId}`, {
+      callback: (data) => setOtherProperties(data.filter((p) => p.buildingData.id !== apt.id)),
+    });
+  }, [apt]);
+
+  useEffect(() => {
+    const checkSaved = async () => {
+      if (!user) {
+        setIsSaved(false);
+        return;
+      }
+      try {
+        const token = await user.getIdToken(true);
+        const res = await axios.post(
+          '/api/check-saved-apartment',
+          { apartmentId: aptId },
+          createAuthHeaders(token)
+        );
+        setIsSaved(res.data.result);
+      } catch {
+        /* silent */
+      }
+    };
+    checkSaved();
+  }, [user, aptId]);
+
+  useEffect(() => subscribeLikes(setLikedReviews), []);
+
+  useEffect(() => {
+    getUser(false).then((u) => {
+      if (!u) return;
+      u.getIdToken(true).then((token) => {
+        get<ReviewWithId[]>(
+          `/api/review/like/${u.uid}`,
+          {
+            callback: (reviews) => {
+              const liked: Likes = {};
+              const statuses: Likes = {};
+              reviews.forEach((r) => {
+                liked[r.id] = true;
+                statuses[r.id] = false;
+              });
+              setLikedReviews(liked);
+              setLikeStatuses(statuses);
+            },
+          },
+          createAuthHeaders(token)
+        );
+      });
+    });
+  }, []);
+
+  /* ── Derived ── */
+  const averageRating = useMemo(
+    () => (reviewData.length ? getAverageRating(reviewData) : 0),
+    [reviewData]
+  );
+
+  const aveRatingInfo: RatingInfo[] = useMemo(() => {
+    if (!reviewData.length) return [];
+    return ['location', 'safety', 'maintenance', 'conditions'].map((feature) => ({
+      feature,
+      rating:
+        reviewData.reduce(
+          (s, r) => s + r.detailedRatings[feature as keyof typeof r.detailedRatings],
+          0
+        ) / reviewData.length,
+    }));
+  }, [reviewData]);
+
+  const heroPhotos = useMemo(() => apt?.photos ?? [], [apt]);
+
+  const heroGridStyle = (count: number): React.CSSProperties => ({
+    display: 'grid',
+    gridTemplateColumns: count >= 3 ? '5fr 3fr' : count === 2 ? '1fr 1fr' : '1fr',
+    gap: 6,
+    height: 420,
+    position: 'relative',
+    marginBottom: 20,
+  });
+
+  /* ── Toast helpers ── */
+  const showToast = (set: React.Dispatch<React.SetStateAction<boolean>>) => {
+    set(true);
+    setTimeout(() => set(false), toastTime);
+  };
+
+  /* ── Like helpers ── */
+  const likeHelper =
+    (dislike = false) =>
+    async (reviewId: string) => {
+      setLikeStatuses((prev) => ({ ...prev, [reviewId]: true }));
+      try {
+        let u = user;
+        if (!u) {
+          u = await getUser(true);
+          setUser(u);
+        }
+        if (!u) throw new Error('not logged in');
+        const token = await u.getIdToken(true);
+        await axios.post(
+          dislike ? '/api/remove-like' : '/api/add-like',
+          { reviewId },
+          createAuthHeaders(token)
+        );
+        const defaultLikes = dislike ? 1 : 0;
+        const offset = dislike ? -1 : 1;
+        setLikedReviews((prev) => ({ ...prev, [reviewId]: !dislike }));
+        setReviewData((prev) =>
+          prev.map((r) =>
+            r.id === reviewId ? { ...r, likes: (r.likes || defaultLikes) + offset } : r
+          )
+        );
+      } catch {
+        /* silent */
+      }
+      setLikeStatuses((prev) => ({ ...prev, [reviewId]: false }));
+    };
+
+  const addLike = likeHelper(false);
+  const removeLike = likeHelper(true);
+
+  /* ── Save ── */
+  const handleSaveToggle = async () => {
+    try {
+      let u = user;
+      if (!u) {
+        u = await getUser(true);
+        setUser(u);
+      }
+      if (!u) throw new Error('not logged in');
+      const token = await u.getIdToken(true);
+      const endpoint = !isSaved ? '/api/add-saved-apartment' : '/api/remove-saved-apartment';
+      await axios.post(endpoint, { apartmentId: aptId }, createAuthHeaders(token));
+      setIsSaved((prev) => !prev);
+      if (!isSaved) showToast(setShowSaveSuccess);
+    } catch {
+      /* silent */
+    }
+  };
+
+  /* ── Review modal ── */
+  const openReviewModal = async () => {
+    let u = await getUser(true);
+    setUser(u);
+    if (!u) {
+      showToast(setShowSignInError);
+      return;
+    }
+    setReviewOpen(true);
+  };
+
+  if (!apt) {
+    return (
+      <div className={classes.page}>
+        <Typography className={classes.loadingText}>Loading...</Typography>
+      </div>
+    );
+  }
+
+  return (
+    <div className={classes.page}>
+      <Container maxWidth="lg" style={{ paddingTop: 20 }}>
+        {/* ─────────── Hero ─────────── */}
+        <div style={heroGridStyle(heroPhotos.length)} data-testid="hero-section">
+          {/* 0 photos: full-width placeholder */}
+          {heroPhotos.length === 0 && (
+            <div className={classes.heroPlaceholder} data-testid="hero-image-primary" />
+          )}
+
+          {/* 1+ photos: primary image always rendered */}
+          {heroPhotos.length >= 1 && (
+            <img
+              src={heroPhotos[0]}
+              alt="Apartment main"
+              className={classes.heroPrimary}
+              data-testid="hero-image-primary"
+            />
+          )}
+
+          {/* 2 photos: second image fills right column equally */}
+          {heroPhotos.length === 2 && (
+            <img
+              src={heroPhotos[1]}
+              alt="Apartment secondary"
+              className={classes.heroPrimary}
+              data-testid="hero-image-secondary-top"
+            />
+          )}
+
+          {/* 3+ photos: two smaller images stacked in right column */}
+          {heroPhotos.length >= 3 && (
+            <div className={classes.heroSecondaryCol}>
+              <img
+                src={heroPhotos[1]}
+                alt="Apartment secondary"
+                className={classes.heroSecondary}
+                data-testid="hero-image-secondary-top"
+              />
+              <img
+                src={heroPhotos[2]}
+                alt="Apartment tertiary"
+                className={classes.heroSecondary}
+                data-testid="hero-image-secondary-bottom"
+              />
+            </div>
+          )}
+
+          <button
+            type="button"
+            className={classes.galleryBtn}
+            data-testid="gallery-button"
+            onClick={() => showPhotoCarousel()}
+          >
+            Gallery
+          </button>
+        </div>
+
+        {/* ─────────── Two-column body ─────────── */}
+        <Grid container spacing={3}>
+          {/* Left column */}
+          <Grid item xs={12} md={7}>
+            {/* Apt header */}
+            <div className={classes.aptHeaderRow} data-testid="apt-header-section">
+              <Typography component="h1" className={classes.aptTitle}>
+                {apt.name}
+              </Typography>
+              <div className={classes.actionBtns}>
+                <Button
+                  className={classes.saveBtn}
+                  onClick={handleSaveToggle}
+                  disableElevation
+                  disableRipple
+                >
+                  <img
+                    src={isSaved ? savedIcon : unsavedIcon}
+                    alt="save"
+                    className={classes.bookmarkIcon}
+                  />
+                  {isSaved ? 'Saved' : 'Save'}
+                </Button>
+                <Button className={classes.outlineBtn} disableElevation disableRipple>
+                  Share
+                </Button>
+                <Button
+                  className={classes.outlineBtn}
+                  disableElevation
+                  disableRipple
+                  onClick={() => history.push(`/compare?aptIds=${aptId}`)}
+                >
+                  Compare
+                </Button>
+              </div>
+            </div>
+            <Typography className={classes.aptDescription} style={{ marginBottom: 16 }}>
+              {apt.description}
+            </Typography>
+
+            {/* Rating summary */}
+            <RatingSummary
+              aveRatingInfo={aveRatingInfo}
+              averageRating={averageRating}
+              numReviews={reviewData.length}
+            />
+
+            {/* Reviews */}
+            <div style={{ marginBottom: 24 }}>
+              <div className={classes.reviewsHeader}>
+                <Typography className={classes.sectionHeading}>Reviews</Typography>
+                <Button
+                  className={classes.outlineBtnRed}
+                  onClick={openReviewModal}
+                  disableElevation
+                  disableRipple
+                >
+                  Leave a review
+                </Button>
+              </div>
+
+              {reviewData.length === 0 ? (
+                <Typography className={classes.emptyText}>No reviews yet</Typography>
+              ) : (
+                <>
+                  {sortReviews([...reviewData], sortBy)
+                    .slice(0, resultsToShow)
+                    .map((review) => (
+                      <ReviewComponent
+                        key={review.id}
+                        showLabel={false}
+                        review={review}
+                        liked={likedReviews[review.id]}
+                        likeLoading={likeStatuses[review.id]}
+                        addLike={addLike}
+                        removeLike={removeLike}
+                        setToggle={setToggle}
+                        triggerEditToast={() => showToast(setShowEditSuccess)}
+                        triggerDeleteToast={() => showToast(setShowDeleteSuccess)}
+                        triggerReportToast={() => showToast(setShowReportSuccess)}
+                        triggerPhotoCarousel={showPhotoCarousel}
+                        user={user}
+                        setUser={setUser}
+                      />
+                    ))}
+                  {resultsToShow < reviewData.length && (
+                    <Button
+                      className={classes.showMoreBtn}
+                      onClick={() => setResultsToShow((n) => n + 5)}
+                      disableElevation
+                      disableRipple
+                    >
+                      Show more
+                    </Button>
+                  )}
+                </>
+              )}
+            </div>
+
+            {/* Floor Plan */}
+            <div style={{ marginBottom: 24 }} data-testid="floor-plan-section">
+              <Typography className={classes.sectionHeading}>Floor Plan</Typography>
+              {(apt.floorplans ?? []).length === 0 ? (
+                <Typography className={classes.emptyText}>No floor plan data available</Typography>
+              ) : (
+                (apt.floorplans ?? []).map((plan, i) => <FloorPlanCard key={i} plan={plan} />)
+              )}
+            </div>
+
+            {/* Amenities */}
+            <div style={{ marginBottom: 24 }} data-testid="amenities-section">
+              <Typography className={classes.sectionHeading}>Amenities</Typography>
+              {(apt.amenities ?? []).length === 0 ? (
+                <Typography className={classes.emptyText}>No available amenities</Typography>
+              ) : (
+                <div className={classes.amenitiesGrid}>
+                  {(apt.amenities ?? []).map((amenity) => (
+                    <div key={amenity} className={classes.amenityPill}>
+                      {AMENITY_ICONS[amenity.toLowerCase()] ?? null}
+                      <span>{amenity}</span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </Grid>
+
+          {/* Right column */}
+          <Grid item xs={12} md={5}>
+            {/* Location */}
+            <div data-testid="location-section" style={{ marginBottom: 8 }}>
+              <Typography className={classes.sectionHeading}>Location</Typography>
+              <MapInfo
+                address={apt.address}
+                latitude={apt.latitude}
+                longitude={apt.longitude}
+                travelTimes={travelTimes}
+                handleClick={() => setMapOpen(true)}
+                mapToggle={mapToggle}
+                isMobile={false}
+              />
+            </div>
+
+            {/* Landlord */}
+            {landlordData && (
+              <div data-testid="landlord-section">
+                <Typography className={classes.sectionHeading}>Landlord</Typography>
+                <div className={classes.landlordCard}>
+                  <Typography className={classes.landlordInfoLabel}>
+                    Landlord information
+                  </Typography>
+                  <Typography className={classes.landlordName}>{landlordData.name}</Typography>
+                  {landlordData.address && (
+                    <Typography className={classes.landlordAddress}>
+                      Address: {landlordData.address}
+                    </Typography>
+                  )}
+                  <Button
+                    variant="contained"
+                    className={classes.msgLandlordBtn}
+                    href={`/landlord/${apt.landlordId}`}
+                    disableElevation
+                  >
+                    Message Landlord
+                  </Button>
+                  {landlordData.contact && (
+                    <Button
+                      variant="outlined"
+                      className={classes.visitBtn}
+                      href={landlordData.contact}
+                      target="_blank"
+                      rel="noreferrer"
+                      disableElevation
+                    >
+                      Visit Property Website
+                    </Button>
+                  )}
+                </div>
+              </div>
+            )}
+          </Grid>
+        </Grid>
+
+        {/* ─────────── Other Similar Properties ─────────── */}
+        {otherProperties.length > 0 && (
+          <div style={{ marginTop: 24 }} data-testid="similar-properties-section">
+            <Typography className={classes.sectionHeading}>Other Similar Properties</Typography>
+            <div className={classes.similarRow}>
+              {otherProperties.map(({ buildingData, numReviews, avgRating }) => (
+                <div key={buildingData.id} className={classes.similarCardWrapper}>
+                  <NewApartmentCard
+                    buildingData={buildingData}
+                    numReviews={numReviews}
+                    avgRating={avgRating ?? 0}
+                    user={user}
+                    setUser={setUser}
+                  />
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </Container>
+
+      {/* ─────────── Modals ─────────── */}
+      <MapModal
+        aptName={apt.name}
+        open={mapOpen}
+        onClose={() => {
+          setMapOpen(false);
+          setMapToggle((p) => !p);
+        }}
+        address={apt.address}
+        longitude={apt.longitude}
+        latitude={apt.latitude}
+        travelTimes={travelTimes}
+        isMobile={false}
+      />
+
+      {apt.landlordId && (
+        <ReviewModal
+          open={reviewOpen}
+          onClose={() => setReviewOpen(false)}
+          setOpen={setReviewOpen}
+          landlordId={apt.landlordId}
+          onSuccess={() => showToast(setShowConfirmation)}
+          toastTime={toastTime}
+          aptId={apt.id}
+          aptName={apt.name}
+          user={user}
+        />
+      )}
+
+      <PhotoCarousel
+        photos={carouselPhotos}
+        open={carouselOpen}
+        startIndex={carouselStartIndex}
+        onClose={closePhotoCarousel}
+      />
+
+      {/* ─────────── Toasts ─────────── */}
+      <Toast
+        isOpen={showConfirmation}
+        severity="success"
+        message="Review submitted! Awaiting admin approval."
+        time={toastTime}
+      />
+      <Toast
+        isOpen={showSignInError}
+        severity="error"
+        message="Please sign in with a Cornell email."
+        time={toastTime}
+      />
+      <Toast
+        isOpen={showEditSuccess}
+        severity="success"
+        message="Review edited successfully."
+        time={toastTime}
+      />
+      <Toast
+        isOpen={showDeleteSuccess}
+        severity="success"
+        message="Review deleted successfully."
+        time={toastTime}
+      />
+      <Toast
+        isOpen={showReportSuccess}
+        severity="success"
+        message="Review reported."
+        time={toastTime}
+      />
+      <Toast
+        isOpen={showSaveSuccess}
+        severity="success"
+        message={`You have bookmarked ${apt.name}. View your bookmarks `}
+        time={toastTime}
+        linkMessage="here"
+        link="/bookmarks"
+      />
+    </div>
+  );
+};
+
+export default NewApartmentPage;

--- a/frontend/src/pages/newApartmentPage.tsx
+++ b/frontend/src/pages/newApartmentPage.tsx
@@ -56,11 +56,14 @@ const AMENITY_ICONS: Record<string, ReactElement> = {
   'no pets': <PetsIcon fontSize="small" />,
 };
 
-const useStyles = makeStyles({
+const useStyles = makeStyles((theme) => ({
   page: {
     backgroundColor: colors.gray3,
     minHeight: '100vh',
     paddingBottom: 48,
+    [theme.breakpoints.down('xs')]: {
+      paddingBottom: 32,
+    },
   },
   innerPage: {
     maxWidth: 1200,
@@ -117,6 +120,12 @@ const useStyles = makeStyles({
     alignItems: 'flex-start',
     gap: 16,
     marginBottom: 12,
+    // Below sm the title and the three action buttons cannot share a row
+    // without the buttons collapsing to unreadable widths.
+    [theme.breakpoints.down('xs')]: {
+      flexDirection: 'column',
+      gap: 12,
+    },
   },
   aptTitle: {
     fontWeight: 700,
@@ -125,6 +134,10 @@ const useStyles = makeStyles({
     margin: 0,
     marginBottom: 8,
     color: colors.black,
+    [theme.breakpoints.down('xs')]: {
+      fontSize: 24,
+      marginBottom: 6,
+    },
   },
   aptDescription: {
     fontSize: 15,
@@ -132,6 +145,9 @@ const useStyles = makeStyles({
     marginBottom: 0,
     maxWidth: 680,
     lineHeight: 1.55,
+    [theme.breakpoints.down('xs')]: {
+      fontSize: 14,
+    },
   },
   actionBtns: {
     display: 'flex',
@@ -139,6 +155,12 @@ const useStyles = makeStyles({
     flexShrink: 0,
     alignItems: 'flex-start',
     paddingTop: 4,
+    [theme.breakpoints.down('xs')]: {
+      width: '100%',
+      paddingTop: 0,
+      flexWrap: 'wrap',
+      '& > *': { flex: '1 1 auto' },
+    },
   },
   saveBtn: {
     background: colors.red1,
@@ -188,6 +210,10 @@ const useStyles = makeStyles({
     marginBottom: 12,
     marginTop: 4,
     color: colors.black,
+    [theme.breakpoints.down('xs')]: {
+      fontSize: 19,
+      marginBottom: 10,
+    },
   },
 
   /* ── Reviews ── */
@@ -196,6 +222,12 @@ const useStyles = makeStyles({
     justifyContent: 'space-between',
     alignItems: 'center',
     marginBottom: 12,
+    // The sort dropdown and "Leave a review" button wrap under the heading
+    // rather than squeezing onto one line.
+    [theme.breakpoints.down('xs')]: {
+      flexWrap: 'wrap',
+      gap: 8,
+    },
   },
   emptyText: {
     color: colors.gray1,
@@ -239,6 +271,9 @@ const useStyles = makeStyles({
     borderRadius: 12,
     padding: '16px 20px',
     marginBottom: 8,
+    [theme.breakpoints.down('xs')]: {
+      padding: '14px 16px',
+    },
   },
   landlordInfoLabel: {
     fontWeight: 500,
@@ -294,7 +329,7 @@ const useStyles = makeStyles({
     textAlign: 'center',
     color: colors.gray1,
   },
-});
+}));
 
 /**
  * NewApartmentPage is the fully-redesigned apartment detail page.
@@ -507,11 +542,23 @@ const NewApartmentPage = ({ user, setUser }: Props): ReactElement => {
     return contact && /^https?:\/\//i.test(contact) ? contact : null;
   }, [landlordData]);
 
+  /**
+   * heroGridStyle – Builds the hero photo grid layout for a given photo count.
+   *
+   * @remarks
+   * On narrow screens the secondary column is dropped entirely: at phone width
+   * the 3fr column renders thumbnails too small to be useful, and the full
+   * 420px height consumes most of the viewport before any content is visible.
+   *
+   * @param {number} count – Number of photos available for the apartment.
+   *
+   * @return {React.CSSProperties} – Inline grid styles for the hero container.
+   */
   const heroGridStyle = (count: number): React.CSSProperties => ({
     display: 'grid',
-    gridTemplateColumns: count >= 3 ? '5fr 3fr' : count === 2 ? '1fr 1fr' : '1fr',
+    gridTemplateColumns: isMobile || count < 2 ? '1fr' : count >= 3 ? '5fr 3fr' : '1fr 1fr',
     gap: 6,
-    height: 420,
+    height: isMobile ? 240 : 420,
     position: 'relative',
     marginBottom: 20,
   });
@@ -619,8 +666,10 @@ const NewApartmentPage = ({ user, setUser }: Props): ReactElement => {
             />
           )}
 
-          {/* 2 photos: second image fills right column equally */}
-          {heroPhotos.length === 2 && (
+          {/* 2 photos: second image fills right column equally.
+              Suppressed on mobile, where the grid collapses to one column and
+              the extra images are reachable through the gallery instead. */}
+          {!isMobile && heroPhotos.length === 2 && (
             <img
               src={heroPhotos[1]}
               alt="Apartment secondary"
@@ -630,7 +679,7 @@ const NewApartmentPage = ({ user, setUser }: Props): ReactElement => {
           )}
 
           {/* 3+ photos: two smaller images stacked in right column */}
-          {heroPhotos.length >= 3 && (
+          {!isMobile && heroPhotos.length >= 3 && (
             <div className={classes.heroSecondaryCol}>
               <img
                 src={heroPhotos[1]}

--- a/frontend/src/pages/newApartmentPage.tsx
+++ b/frontend/src/pages/newApartmentPage.tsx
@@ -10,6 +10,7 @@ import WeekendIcon from '@material-ui/icons/Weekend';
 import { useParams, useHistory } from 'react-router-dom';
 import axios from 'axios';
 import {
+  ApartmentFloorPlan,
   ApartmentWithId,
   Landlord,
   LocationTravelTimes,
@@ -537,6 +538,27 @@ const NewApartmentPage = ({ user, setUser }: Props): ReactElement => {
 
   const heroPhotos = useMemo(() => apt?.photos ?? [], [apt]);
 
+  /**
+   * Floor plans to display, falling back to the apartment's room types.
+   *
+   * @remarks
+   * No current data source populates `floorplans`: the room data collected by
+   * the PM team and the agency scrapers both supply bed/bath/price only. Rather
+   * than show an empty section, derive rows from `roomTypes` when no true floor
+   * plans exist. Square footage, unit counts, and imagery are simply absent from
+   * derived rows, and FloorPlanCard omits those lines. Real floor plans always
+   * take precedence once they exist.
+   */
+  const floorPlans: ApartmentFloorPlan[] = useMemo(() => {
+    const existing = apt?.floorplans ?? [];
+    if (existing.length > 0) return [...existing];
+    return (apt?.roomTypes ?? []).map((roomType) => ({
+      bedrooms: roomType.beds,
+      bathrooms: roomType.baths,
+      costPerPerson: roomType.price,
+    }));
+  }, [apt]);
+
   const landlordContactUrl = useMemo(() => {
     const contact = landlordData?.contact;
     return contact && /^https?:\/\//i.test(contact) ? contact : null;
@@ -826,10 +848,10 @@ const NewApartmentPage = ({ user, setUser }: Props): ReactElement => {
             {/* Floor Plan */}
             <div style={{ marginBottom: 24 }} data-testid="floor-plan-section">
               <Typography className={classes.sectionHeading}>Floor Plan</Typography>
-              {(apt.floorplans ?? []).length === 0 ? (
+              {floorPlans.length === 0 ? (
                 <Typography className={classes.emptyText}>No floor plan data available</Typography>
               ) : (
-                (apt.floorplans ?? []).map((plan, i) => <FloorPlanCard key={i} plan={plan} />)
+                floorPlans.map((plan, i) => <FloorPlanCard key={i} plan={plan} />)
               )}
             </div>
 

--- a/frontend/src/pages/newApartmentPage.tsx
+++ b/frontend/src/pages/newApartmentPage.tsx
@@ -1,5 +1,13 @@
 import React, { ReactElement, useEffect, useMemo, useState } from 'react';
-import { Button, Container, Grid, Typography, makeStyles, useMediaQuery } from '@material-ui/core';
+import {
+  Button,
+  Container,
+  Grid,
+  Link,
+  Typography,
+  makeStyles,
+  useMediaQuery,
+} from '@material-ui/core';
 import DirectionsCarIcon from '@material-ui/icons/DirectionsCar';
 import LocalLaundryServiceIcon from '@material-ui/icons/LocalLaundryService';
 import KitchenIcon from '@material-ui/icons/Kitchen';
@@ -7,7 +15,7 @@ import WifiIcon from '@material-ui/icons/Wifi';
 import WhatshotIcon from '@material-ui/icons/Whatshot';
 import PetsIcon from '@material-ui/icons/Pets';
 import WeekendIcon from '@material-ui/icons/Weekend';
-import { useParams, useHistory } from 'react-router-dom';
+import { useParams, useHistory, Link as RouterLink } from 'react-router-dom';
 import axios from 'axios';
 import {
   ApartmentFloorPlan,
@@ -956,13 +964,22 @@ const NewApartmentPage = ({ user, setUser }: Props): ReactElement => {
             <div className={classes.similarRow}>
               {otherProperties.map(({ buildingData, numReviews, avgRating }) => (
                 <div key={buildingData.id} className={classes.similarCardWrapper}>
-                  <NewApartmentCard
-                    buildingData={buildingData}
-                    numReviews={numReviews}
-                    avgRating={avgRating ?? 0}
-                    user={user}
-                    setUser={setUser}
-                  />
+                  {/* NewApartmentCard carries no link of its own, so every
+                      caller has to supply one. Without this the cards render
+                      but clicking them does nothing. */}
+                  <Link
+                    component={RouterLink}
+                    to={`/apartment/${buildingData.id}`}
+                    style={{ textDecoration: 'none' }}
+                  >
+                    <NewApartmentCard
+                      buildingData={buildingData}
+                      numReviews={numReviews}
+                      avgRating={avgRating ?? 0}
+                      user={user}
+                      setUser={setUser}
+                    />
+                  </Link>
                 </div>
               ))}
             </div>

--- a/frontend/src/pages/newApartmentPage.tsx
+++ b/frontend/src/pages/newApartmentPage.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useEffect, useMemo, useState } from 'react';
-import { Button, Container, Grid, Typography, makeStyles } from '@material-ui/core';
+import { Button, Container, Grid, Typography, makeStyles, useMediaQuery } from '@material-ui/core';
 import DirectionsCarIcon from '@material-ui/icons/DirectionsCar';
 import LocalLaundryServiceIcon from '@material-ui/icons/LocalLaundryService';
 import KitchenIcon from '@material-ui/icons/Kitchen';
@@ -35,6 +35,7 @@ import NewApartmentCard from '../components/ApartmentCard/NewApartmentCard';
 import RatingSummary from '../components/Apartment/RatingSummary';
 import FloorPlanCard from '../components/Apartment/FloorPlanCard';
 import Toast from '../components/utils/Toast';
+import DropDownWithLabel from '../components/utils/DropDownWithLabel';
 import savedIcon from '../assets/saved-icon-filled.svg';
 import unsavedIcon from '../assets/saved-icon-unfilled.svg';
 
@@ -306,6 +307,7 @@ const NewApartmentPage = ({ user, setUser }: Props): ReactElement => {
   const classes = useStyles();
   const { aptId } = useParams<Record<string, string>>();
   const history = useHistory();
+  const isMobile = useMediaQuery('(max-width:600px)');
 
   /* ── State ── */
   const [apt, setApt] = useState<ApartmentWithId | null>(null);
@@ -316,7 +318,7 @@ const NewApartmentPage = ({ user, setUser }: Props): ReactElement => {
   const [otherProperties, setOtherProperties] = useState<CardData[]>([]);
   const [travelTimes, setTravelTimes] = useState<LocationTravelTimes | undefined>(undefined);
   const [isSaved, setIsSaved] = useState(false);
-  const sortBy: Fields = 'date';
+  const [sortBy, setSortBy] = useState<Fields>('date');
   const [resultsToShow, setResultsToShow] = useState(5);
   const [likedReviews, setLikedReviews] = useState<Likes>({});
   const [likeStatuses, setLikeStatuses] = useState<Likes>({});
@@ -500,6 +502,11 @@ const NewApartmentPage = ({ user, setUser }: Props): ReactElement => {
 
   const heroPhotos = useMemo(() => apt?.photos ?? [], [apt]);
 
+  const landlordContactUrl = useMemo(() => {
+    const contact = landlordData?.contact;
+    return contact && /^https?:\/\//i.test(contact) ? contact : null;
+  }, [landlordData]);
+
   const heroGridStyle = (count: number): React.CSSProperties => ({
     display: 'grid',
     gridTemplateColumns: count >= 3 ? '5fr 3fr' : count === 2 ? '1fr 1fr' : '1fr',
@@ -640,14 +647,17 @@ const NewApartmentPage = ({ user, setUser }: Props): ReactElement => {
             </div>
           )}
 
-          <button
-            type="button"
-            className={classes.galleryBtn}
-            data-testid="gallery-button"
-            onClick={() => showPhotoCarousel()}
-          >
-            Gallery
-          </button>
+          {/* Hidden with no photos: the carousel would open on an empty list. */}
+          {heroPhotos.length > 0 && (
+            <button
+              type="button"
+              className={classes.galleryBtn}
+              data-testid="gallery-button"
+              onClick={() => showPhotoCarousel()}
+            >
+              Gallery
+            </button>
+          )}
         </div>
 
         {/* ─────────── Two-column body ─────────── */}
@@ -701,14 +711,27 @@ const NewApartmentPage = ({ user, setUser }: Props): ReactElement => {
             <div style={{ marginBottom: 24 }}>
               <div className={classes.reviewsHeader}>
                 <Typography className={classes.sectionHeading}>Reviews</Typography>
-                <Button
-                  className={classes.outlineBtnRed}
-                  onClick={openReviewModal}
-                  disableElevation
-                  disableRipple
-                >
-                  Leave a review
-                </Button>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                  <DropDownWithLabel
+                    label="Sort by"
+                    menuItems={[
+                      { item: 'Recent', callback: () => setSortBy('date') },
+                      { item: 'Helpful', callback: () => setSortBy('likes') },
+                    ]}
+                    isMobile={isMobile}
+                  />
+                  {/* A review is filed against a landlord, so an apartment with
+                      no landlord on record cannot accept one. */}
+                  <Button
+                    className={classes.outlineBtnRed}
+                    onClick={openReviewModal}
+                    disabled={!apt.landlordId}
+                    disableElevation
+                    disableRipple
+                  >
+                    Leave a review
+                  </Button>
+                </div>
               </div>
 
               {reviewData.length === 0 ? (
@@ -791,7 +814,7 @@ const NewApartmentPage = ({ user, setUser }: Props): ReactElement => {
                 travelTimes={travelTimes}
                 handleClick={() => setMapOpen(true)}
                 mapToggle={mapToggle}
-                isMobile={false}
+                isMobile={isMobile}
               />
             </div>
 
@@ -817,11 +840,15 @@ const NewApartmentPage = ({ user, setUser }: Props): ReactElement => {
                   >
                     Message Landlord
                   </Button>
-                  {landlordData.contact && (
+                  {/* `contact` holds an email address for some landlords and a
+                      website for others. Only link it when it is an absolute
+                      URL; an email address here would resolve as a relative
+                      path and navigate within the app. */}
+                  {landlordContactUrl && (
                     <Button
                       variant="outlined"
                       className={classes.visitBtn}
-                      href={landlordData.contact}
+                      href={landlordContactUrl}
                       target="_blank"
                       rel="noreferrer"
                       disableElevation
@@ -868,7 +895,7 @@ const NewApartmentPage = ({ user, setUser }: Props): ReactElement => {
         longitude={apt.longitude}
         latitude={apt.latitude}
         travelTimes={travelTimes}
-        isMobile={false}
+        isMobile={isMobile}
       />
 
       {apt.landlordId && (

--- a/frontend/src/pages/newApartmentPage.tsx
+++ b/frontend/src/pages/newApartmentPage.tsx
@@ -76,18 +76,26 @@ const useStyles = makeStyles((theme) => ({
   heroPrimary: {
     width: '100%',
     height: '100%',
+    // Without this a grid item refuses to shrink below its content size, which
+    // for an <img> is the photo's natural height.
+    minHeight: 0,
     objectFit: 'cover',
     borderRadius: 12,
     display: 'block',
   },
   heroSecondaryCol: {
     display: 'grid',
-    gridTemplateRows: '1fr 1fr',
+    // `1fr` is shorthand for `minmax(auto, 1fr)`, and that `auto` floor is the
+    // image's natural height. Spelling out a zero floor lets the two stacked
+    // photos split the column evenly instead of overflowing it.
+    gridTemplateRows: 'minmax(0, 1fr) minmax(0, 1fr)',
     gap: 6,
+    minHeight: 0,
   },
   heroSecondary: {
     width: '100%',
     height: '100%',
+    minHeight: 0,
     objectFit: 'cover',
     borderRadius: 12,
     display: 'block',
@@ -579,8 +587,14 @@ const NewApartmentPage = ({ user, setUser }: Props): ReactElement => {
   const heroGridStyle = (count: number): React.CSSProperties => ({
     display: 'grid',
     gridTemplateColumns: isMobile || count < 2 ? '1fr' : count >= 3 ? '5fr 3fr' : '1fr 1fr',
+    // The row has to be pinned to the container height. Left implicit it sizes
+    // to `auto`, which for a grid row means "at least as tall as the content",
+    // so a photo taller than the container grows the row instead of being
+    // cropped and the hero paints over the section below it.
+    gridTemplateRows: '100%',
     gap: 6,
     height: isMobile ? 240 : 420,
+    overflow: 'hidden',
     position: 'relative',
     marginBottom: 20,
   });

--- a/frontend/src/pages/newApartmentPage.tsx
+++ b/frontend/src/pages/newApartmentPage.tsx
@@ -761,7 +761,9 @@ const NewApartmentPage = ({ user, setUser }: Props): ReactElement => {
                   className={classes.outlineBtn}
                   disableElevation
                   disableRipple
-                  onClick={() => history.push(`/compare?aptIds=${aptId}`)}
+                  // The comparison page reads its apartments from an `ids`
+                  // query parameter; the name must match or it loads empty.
+                  onClick={() => history.push(`/compare?ids=${aptId}`)}
                 >
                   Compare
                 </Button>

--- a/frontend/src/pages/newApartmentPage.tsx
+++ b/frontend/src/pages/newApartmentPage.tsx
@@ -23,6 +23,7 @@ import { createAuthHeaders, getUser, subscribeLikes } from '../utils/firebase';
 import { Likes } from '../../../common/types/db-types';
 import { sortReviews } from '../utils/sortReviews';
 import { RatingInfo } from './ApartmentPage';
+import NotFoundPage from './NotFoundPage';
 
 import ReviewComponent from '../components/Review/Review';
 import ReviewModal from '../components/LeaveReview/ReviewModal';
@@ -308,7 +309,9 @@ const NewApartmentPage = ({ user, setUser }: Props): ReactElement => {
 
   /* ── State ── */
   const [apt, setApt] = useState<ApartmentWithId | null>(null);
+  const [notFound, setNotFound] = useState(false);
   const [reviewData, setReviewData] = useState<ReviewWithId[]>([]);
+  const [reviewsFailed, setReviewsFailed] = useState(false);
   const [landlordData, setLandlordData] = useState<Landlord | null>(null);
   const [otherProperties, setOtherProperties] = useState<CardData[]>([]);
   const [travelTimes, setTravelTimes] = useState<LocationTravelTimes | undefined>(undefined);
@@ -339,32 +342,96 @@ const NewApartmentPage = ({ user, setUser }: Props): ReactElement => {
   } = usePhotoCarousel(apt?.photos ?? []);
 
   /* ── Data fetching ── */
+  // Every fetch below is guarded by a `stale` flag so a slow response for a
+  // previously viewed apartment cannot overwrite the current one. Navigating
+  // between apartments reuses this component instance (only `aptId` changes),
+  // so state must also be cleared up front rather than left showing the
+  // previous apartment while the new one loads.
   useEffect(() => {
+    let stale = false;
+
+    setApt(null);
+    setNotFound(false);
+    setTravelTimes(undefined);
+    setLandlordData(null);
+    setOtherProperties([]);
+    setReviewData([]);
+    setResultsToShow(5);
+
     get<ApartmentWithId[]>(`/api/apts/${aptId}`, {
-      callback: (data) => setApt(data[0] ?? null),
+      callback: (data) => {
+        if (stale) return;
+        const found = data[0];
+        if (found) {
+          setApt(found);
+        } else {
+          setNotFound(true);
+        }
+      },
+      errorHandler: () => {
+        if (!stale) setNotFound(true);
+      },
     });
     get<LocationTravelTimes>(`/api/travel-times-by-id/${aptId}`, {
-      callback: setTravelTimes,
+      callback: (data) => {
+        if (!stale) setTravelTimes(data);
+      },
+      // Travel times are supplementary; a failure here leaves the map section
+      // empty rather than failing the whole page.
+      errorHandler: () => undefined,
     });
+
+    return () => {
+      stale = true;
+    };
   }, [aptId]);
 
   useEffect(() => {
+    let stale = false;
     const fetchReviews = async () => {
-      const [approved, reported] = await Promise.all([
-        axios.get<ReviewWithId[]>(`/api/review/aptId/${aptId}/APPROVED`),
-        axios.get<ReviewWithId[]>(`/api/review/aptId/${aptId}/REPORTED`),
-      ]);
-      setReviewData([...approved.data, ...reported.data]);
+      try {
+        const [approved, reported] = await Promise.all([
+          axios.get<ReviewWithId[]>(`/api/review/aptId/${aptId}/APPROVED`),
+          axios.get<ReviewWithId[]>(`/api/review/aptId/${aptId}/REPORTED`),
+        ]);
+        if (!stale) {
+          setReviewData([...approved.data, ...reported.data]);
+          setReviewsFailed(false);
+        }
+      } catch (err) {
+        // Distinguish "this apartment has no reviews" from "we could not load
+        // them", so the empty state does not misreport a server error.
+        console.error(err);
+        if (!stale) {
+          setReviewData([]);
+          setReviewsFailed(true);
+        }
+      }
     };
     fetchReviews();
+    return () => {
+      stale = true;
+    };
   }, [aptId, toggle]);
 
   useEffect(() => {
-    if (!apt?.landlordId) return;
-    get<Landlord>(`/api/landlord/${apt.landlordId}`, { callback: setLandlordData });
-    get<CardData[]>(`/api/buildings/all/${apt.landlordId}`, {
-      callback: (data) => setOtherProperties(data.filter((p) => p.buildingData.id !== apt.id)),
+    if (!apt?.landlordId) return undefined;
+    let stale = false;
+    get<Landlord>(`/api/landlord/${apt.landlordId}`, {
+      callback: (data) => {
+        if (!stale) setLandlordData(data);
+      },
+      errorHandler: () => undefined,
     });
+    get<CardData[]>(`/api/buildings/all/${apt.landlordId}`, {
+      callback: (data) => {
+        if (!stale) setOtherProperties(data.filter((p) => p.buildingData.id !== apt.id));
+      },
+      errorHandler: () => undefined,
+    });
+    return () => {
+      stale = true;
+    };
   }, [apt]);
 
   useEffect(() => {
@@ -422,13 +489,12 @@ const NewApartmentPage = ({ user, setUser }: Props): ReactElement => {
 
   const aveRatingInfo: RatingInfo[] = useMemo(() => {
     if (!reviewData.length) return [];
-    return ['location', 'safety', 'maintenance', 'conditions'].map((feature) => ({
+    // detailedRatings is optional-chained because a malformed review missing
+    // the field would otherwise make the whole page throw, not just this panel.
+    return (['location', 'safety', 'maintenance', 'conditions'] as const).map((feature) => ({
       feature,
       rating:
-        reviewData.reduce(
-          (s, r) => s + r.detailedRatings[feature as keyof typeof r.detailedRatings],
-          0
-        ) / reviewData.length,
+        reviewData.reduce((s, r) => s + (r.detailedRatings?.[feature] ?? 0), 0) / reviewData.length,
     }));
   }, [reviewData]);
 
@@ -513,6 +579,10 @@ const NewApartmentPage = ({ user, setUser }: Props): ReactElement => {
     }
     setReviewOpen(true);
   };
+
+  if (notFound) {
+    return <NotFoundPage />;
+  }
 
   if (!apt) {
     return (
@@ -642,7 +712,9 @@ const NewApartmentPage = ({ user, setUser }: Props): ReactElement => {
               </div>
 
               {reviewData.length === 0 ? (
-                <Typography className={classes.emptyText}>No reviews yet</Typography>
+                <Typography className={classes.emptyText}>
+                  {reviewsFailed ? 'Could not load reviews. Please try again.' : 'No reviews yet'}
+                </Typography>
               ) : (
                 <>
                   {sortReviews([...reviewData], sortBy)
@@ -821,44 +893,59 @@ const NewApartmentPage = ({ user, setUser }: Props): ReactElement => {
       />
 
       {/* ─────────── Toasts ─────────── */}
-      <Toast
-        isOpen={showConfirmation}
-        severity="success"
-        message="Review submitted! Awaiting admin approval."
-        time={toastTime}
-      />
-      <Toast
-        isOpen={showSignInError}
-        severity="error"
-        message="Please sign in with a Cornell email."
-        time={toastTime}
-      />
-      <Toast
-        isOpen={showEditSuccess}
-        severity="success"
-        message="Review edited successfully."
-        time={toastTime}
-      />
-      <Toast
-        isOpen={showDeleteSuccess}
-        severity="success"
-        message="Review deleted successfully."
-        time={toastTime}
-      />
-      <Toast
-        isOpen={showReportSuccess}
-        severity="success"
-        message="Review reported."
-        time={toastTime}
-      />
-      <Toast
-        isOpen={showSaveSuccess}
-        severity="success"
-        message={`You have bookmarked ${apt.name}. View your bookmarks `}
-        time={toastTime}
-        linkMessage="here"
-        link="/bookmarks"
-      />
+      {/* Toast latches its `isOpen` prop into state on mount and never syncs
+          it again, so each toast must be mounted only while its flag is set.
+          Rendering them unconditionally makes them permanently invisible. */}
+      {showConfirmation && (
+        <Toast
+          isOpen={showConfirmation}
+          severity="success"
+          message="Review submitted! Awaiting admin approval."
+          time={toastTime}
+        />
+      )}
+      {showSignInError && (
+        <Toast
+          isOpen={showSignInError}
+          severity="error"
+          message="Please sign in with a Cornell email."
+          time={toastTime}
+        />
+      )}
+      {showEditSuccess && (
+        <Toast
+          isOpen={showEditSuccess}
+          severity="success"
+          message="Review edited successfully."
+          time={toastTime}
+        />
+      )}
+      {showDeleteSuccess && (
+        <Toast
+          isOpen={showDeleteSuccess}
+          severity="success"
+          message="Review deleted successfully."
+          time={toastTime}
+        />
+      )}
+      {showReportSuccess && (
+        <Toast
+          isOpen={showReportSuccess}
+          severity="success"
+          message="Review reported."
+          time={toastTime}
+        />
+      )}
+      {showSaveSuccess && (
+        <Toast
+          isOpen={showSaveSuccess}
+          severity="success"
+          message={`You have bookmarked ${apt.name}. View your bookmarks `}
+          time={toastTime}
+          linkMessage="here"
+          link="/bookmarks"
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
### Summary
This PR redesigns the apartment page and adds the necessary backend routes to support it

Frontend:
- [ ] New apartment page (`newApartmentPage.tsx`) with a new photo grid, rating summary, floor plans, amenities, and distance from transportation. Also redesigned reviews, landlord, and map sections.
- [ ]  New `RatingSummary` component. Includes overall score plus a bar per category, and an N/A state when an apartment has no reviews
- [ ] New `FloorPlanCard` component. Includes beds, baths, square footage, availability, and price per person
- [ ] Walking time to the nearest bus stop in addition to existing walking time to places on campus.

Backend:
- [] `GET /api/apartment-rating-summary/:aptId` averages approved reviews into an overall score plus location, maintenance, safety, and conditions
- [] `GET /api/apartment-amenities/:aptId`
- [] `GET /api/apartment-floorplans/:aptId`
- [] `GET /api/bus-stop-travel-times/:buildingId` calculates walking times to the Collegetown bus stops
- [] Moved `getTravelTimes` out of `app.ts` into `travel-times-utils.ts`, alongside new `BUS_STOPS` and `findClosestStop` helpers.
- [] `POST /api/calculate-travel-times` also records the walk to the closest bus stop.

Types:

- [] `Apartment` gets optional `description`, `amenities`, `floorplans`, and `totalRating`
- [] `LocationTravelTimes` gets optional `busStopWalking`


### Test Plan 

The page:

- [ ] /apartment/14 - loads with rating summary, reviews, floor plans, amenities, map, landlord card, and similar properties
- [ ] /apartment/130 - gallery button opens a carousel with 4 photos
- [ ] /apartment/14 - this one has no photos, so the gallery button is hidden rather than opening an empty carousel
- [ ] /apartment/99999 - not-found page, not a permanent "Loading..."
- [ ] Click a similar property from /apartment/130 - new data replaces old, no flash of the previous apartment's reviews
Reviews

- [ ] /apartment/14 has 9 approved reviews. Summary shows an overall score plus a bar each for location, maintenance, safety, and conditions
- [ ] /apartment/20 has none. Summary shows N/A, not zeros
- [ ] Switch the sort between Recent and Helpful, and the order actually changes. 
- [ ] "Show more" shows the remaining reviews
- [ ] Like a review while signed in. The count should go up, click again and it goes back down
- [ ] Save the apartment with.
- [ ] Click "Leave a review" while signed out. It should ask you to sign in 

Floor plans

- [ ] /apartment/51 - you should see two floor plans: 2 Beds 2 baths at $2000 and 3 Beds 2 baths at $3000.
- [ ] No "undefined sqft" anywhere. It is either a defined square footage or it doesn’t appear. 

Map and links

- [ ] Walking times to Eng Quad, Ho Plaza, and Ag Quad all render
- [ ] The bus stop walking time is missing on every apartment. Expected, see my comment in the notes section. 

I checked some things manually as well:
- Rating averages match what I worked out by hand from the raw reviews, on apartments with 9, 4, and 3 reviews
- Apartment 14 has 9 approved, 3 pending, 1 reported, and 7 declined reviews. The summary counts 9
- Bus stop times land between 1 and 6 minutes (reasonable), and each building picks the stop you would expect. 109 College Ave picks Mitchell, 227 Linden picks Collegetown Crossing
- Posting the same location as coordinates and as a bare address returns the same times



### Notes

Things I found and fixed while building the page:

- [] Bus stop times didn't make sense initially. It would say 24 days per stop. The issue was that Adresses are stored without a city, so Google matched `408 College Ave` to a street in Texas. I now made sure that addresses get `Ithaca, NY 14850` appended before they go to Google. Coordinates and addresses that already say Ithaca are left alone.
- [] A missing apartment showed "Loading..." forever. There was no error handler and no not-found state. Renders `NotFoundPage` now.
- [] Going from one apartment to another showed the previous apartment's data until the new request came back. State is cleared when `aptId` changes, and late responses are ignored.
- [] A failed review request looked identical to "no reviews yet". Server errors are reported as errors now.
- [] Review sorting did nothing. `sortBy` was hardcoded to `date`. The Recent/Helpful control works again.
- [] `landlord.contact` was used as a website link, but for some landlords it holds an email address. That resolves as a relative path and navigates inside the app. Only real URLs get linked now.
- [] The gallery button opened an empty carousel on apartments with no photos. Hidden in that case.
- [] `FloorPlanCard` printed "1 Beds 1 bath" and "1 units available", and "undefined sqft" when a field was missing.
- [] `apartment-amenities` returned whatever was stored. `apartment-floorplans` checks `Array.isArray` first, amenities did not, so a string in that field would reach the client and get mapped over. Both fall back to an empty list now.

Bus stop time won't show up until someone runs a backfill. The map reads busStopWalking off the saved travelTimes doc, but none of them have it. They were all written before the field existed.  The route and the component both work, there's just nothing stored yet. POST /api/batch-create-travel-times/:batchSize/:startAfter? regenerates those docs and writes the field. Until that runs, this part of the feature shows nothing.

The rating summary route and the page count different reviews. Route: approved only. Page: approved plus reported, same as the current page on main. 

I matched the compare button to Nigel's PR (#422). It links to /compare?ids=<id>. Until Nigel's PR merges, clicking it lands on a blank page, since App.tsx has no catch-all. 

Amenities, floor plans, and description are empty against real data. Nothing writes those fields yet, and POST /api/admin/migrate-all-apartments-schema overwrites documents with batch.set and no { merge: true }, so anything written there would get wiped. This is pre-existing but something to note. 

The floor plan section falls back to building rows out of roomTypes: beds, baths, price. Those rows have no square footage, unit count, or image, and show a "No image available" placeholder. 

Apartment-amenities and apartment-floorplans return 404 for an unknown ID. Apartment-rating-summary returns 200 with a zeroed summary, because it queries reviews without checking the apartment exists. Maybe this should be changed. 

### Breaking Changes 

`Apartment` gains four optional fields (`description`, `amenities`, `floorplans`, `totalRating`) and `LocationTravelTimes` gains optional `busStopWalking`. They are optional because existing documents do not have them.

POST /api/calculate-travel-times now writes one extra key, busStopWalking, into travelTimes documents. Old documents keep working until someone recalculates them, and everything reading the field handles it being missing.